### PR TITLE
RATEST-148: Failure when a child node is referencing artifacts from the parent module

### DIFF
--- a/src/test/java/org/openmrs/contrib/qaframework/automation/AllergiesSteps.java
+++ b/src/test/java/org/openmrs/contrib/qaframework/automation/AllergiesSteps.java
@@ -26,7 +26,7 @@ public class AllergiesSteps extends Steps {
 
 	@Given("a user clicks on Allergies link from Patient dashboard")
 	public void loadAllergiesPage() {
-		allergyPage = (AllergyPage) dashboardPage.clickOnAllergyManagement()
+		allergyPage = (AllergyPage) dashboardPage.clickOnAllergiesWidgetLink()
 				.waitForPage();
 	}
 


### PR DESCRIPTION
Ticket ID: https://issues.openmrs.org/browse/RATEST-148

Description
Resolving [failure](https://ci.openmrs.org/browse/CONTRIB-QA-588) when a child node is making reference to the parent module