### PR TITLE
RATEST-193: Add windows execution configuration to support devs using  windows os

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,19 @@
                         </goals>
                     </execution>
                     <execution>
+                        <id>make-windows-chromedriver-executable</id>
+                        <phase>process-test-classes</phase>
+                        <configuration>
+                            <target>
+                                <chmod file="target/test-classes/chromedriver/windows/chromedriver.exe" perm="755" />
+                            </target>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
                         <id>make-mac-firefoxdriver-executable</id>
                         <phase>process-test-classes</phase>
                         <configuration>
@@ -101,6 +114,19 @@
                         <configuration>
                             <target>
                                 <chmod file="target/test-classes/firefoxdriver/linux/geckodriver" perm="755"/>
+                            </target>
+                            <failOnError>false</failOnError>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>make-windows-firefoxdriver-executable</id>
+                        <phase>process-test-classes</phase>
+                        <configuration>
+                            <target>
+                                <chmod file="target/test-classes/firefoxdriver/windows/geckodriver.exe" perm="755"/>
                             </target>
                             <failOnError>false</failOnError>
                         </configuration>


### PR DESCRIPTION
Ticket [ID](https://issues.openmrs.org/projects/RATEST/issues/RATEST-193)
Description -> : Add windows execution configuration to support devs using  windows os