### PR TITLE
Fix patient deletion issue in 3.x Clinical flow

### DIFF
--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/04-clinical-visit/clinical-visit.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/04-clinical-visit/clinical-visit.js
@@ -95,7 +95,7 @@ Then('the conditions list should be empty', () => {
 
 When('the user adds a condition', () => {
     cy.contains('Record conditions').click({force: true});
-    cy.get('input[role="searchbox"]').type('Fever');
+    cy.get('input[role="searchbox"]').type('Fever', {force: true});
     cy.contains('Fever').click();
     cy.contains('Save & Close').click({force: true});
 });
@@ -108,5 +108,5 @@ Then('the added condition should be listed', () => {
 
 
 After({tags: '@clinical-visit'}, () => {
-    cy.deletePatient(identifier);
+    cy.deletePatient(patient.uuid);
 });

--- a/src/test/resources/features/refapp-3.x/04-clinical-visit/clinical-visit.feature
+++ b/src/test/resources/features/refapp-3.x/04-clinical-visit/clinical-visit.feature
@@ -13,7 +13,6 @@ Feature: User Settings
   Scenario: The Patient Summary should load properly
     Then the Patient Summary should load properly
 
-
   @clinical-visit
   Scenario: The programs page should function properly
     When the user clicks on "Programs" in the menu


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix the patient deletion issue in the `3.x Clinical flow`
See: https://issues.openmrs.org/browse/RATEST-201

## Approach
- Pass the UUID instead of the identifier