### PR TITLE
RATEST-207: Attach screen recordings of failed 3.x tests to gh-actions

### DIFF
--- a/.github/workflows/refapp-3x-clinical-visit.yml
+++ b/.github/workflows/refapp-3x-clinical-visit.yml
@@ -20,3 +20,9 @@ jobs:
         run: npm install
       - name: Run clinical visit workflow tests
         run: npm run refapp3ClinicalVisit
+      - name: Upload screen recordings of failed tests
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Screen recordings of failed tests
+          path: cypress/videos/refapp-3.x

--- a/.github/workflows/refapp-3x-login.yml
+++ b/.github/workflows/refapp-3x-login.yml
@@ -20,3 +20,9 @@ jobs:
         run: npm install
       - name: Run login workflow tests
         run: npm run refapp3Login
+      - name: Upload screen recordings of failed tests
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Screen recordings of failed tests
+          path: cypress/videos/refapp-3.x

--- a/.github/workflows/refapp-3x-registration.yml
+++ b/.github/workflows/refapp-3x-registration.yml
@@ -20,3 +20,9 @@ jobs:
         run: npm install
       - name: Run patient registration workflow tests
         run: npm run refapp3Registration
+      - name: Upload screen recordings of failed tests
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Screen recordings of failed tests
+          path: cypress/videos/refapp-3.x

--- a/.github/workflows/refapp-3x-settings.yml
+++ b/.github/workflows/refapp-3x-settings.yml
@@ -20,3 +20,9 @@ jobs:
         run: npm install
       - name: Run User settings workflow tests
         run: npm run refapp3Settings
+      - name: Upload screen recordings of failed tests
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Screen recordings of failed tests
+          path: cypress/videos/refapp-3.x

--- a/cypress.json
+++ b/cypress.json
@@ -4,7 +4,7 @@
     "*.feature",
     "**/*.feature"
   ],
-  "video": false,
+  "video": true,
   "defaultCommandTimeout": 120000,
   "baseUrl": "https://openmrs-spa.org/openmrs/spa",
   "env": {


### PR DESCRIPTION
## Purpose
The pull request is to add a new feature of attaching screen recording of failed 3. x tests and this pull request is related to the issue ticket number [RATEST-207](https://issues.openmrs.org/browse/RATEST-207).

## Goals
- To allow developers/stakeholders to identify why tests failing by playing the screen recording without running them locally. 
- To save time

## Approach
1. Make cypress screen recording facility turn on.
2. Make 3. x test GitHub workflows to save the test of failed tests.

### Screenshots


#### Passed test

![passes test](https://user-images.githubusercontent.com/77311602/131457459-49ddd2ed-3611-46a1-9cf7-1301d85c385a.png)

#### Failed test
A failed test - ([Link](https://github.com/openmrs/openmrs-contrib-qaframework/actions/runs/1185218780))

![failed test](https://user-images.githubusercontent.com/77311602/131457523-23c45e2f-de8c-48fc-85a0-e6fbab9f0014.png)




