### PR TITLE
RATEST-207: Attach screen recordings of failed 3.x tests to gh-action

### DIFF
--- a/.github/workflows/refapp-3x-clinical-visit.yml
+++ b/.github/workflows/refapp-3x-clinical-visit.yml
@@ -20,3 +20,9 @@ jobs:
         run: npm install
       - name: Run clinical visit workflow tests
         run: npm run refapp3ClinicalVisit
+      - name: Upload screen recordings of failed tests
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Screen recordings of failed tests
+          path: cypress/videos/refapp-3.x

--- a/.github/workflows/refapp-3x-login.yml
+++ b/.github/workflows/refapp-3x-login.yml
@@ -20,3 +20,9 @@ jobs:
         run: npm install
       - name: Run login workflow tests
         run: npm run refapp3Login
+      - name: Upload screen recordings of failed tests
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Screen recordings of failed tests
+          path: cypress/videos/refapp-3.x

--- a/.github/workflows/refapp-3x-search-and-registration.yml
+++ b/.github/workflows/refapp-3x-search-and-registration.yml
@@ -20,3 +20,9 @@ jobs:
         run: npm install
       - name: Run patient registration workflow tests
         run: npm run refapp3SearchAndRegistration
+      - name: Upload screen recordings of failed tests
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Screen recordings of failed tests
+          path: cypress/videos/refapp-3.x

--- a/.github/workflows/refapp-3x-settings.yml
+++ b/.github/workflows/refapp-3x-settings.yml
@@ -20,3 +20,9 @@ jobs:
         run: npm install
       - name: Run User settings workflow tests
         run: npm run refapp3Settings
+      - name: Upload screen recordings of failed tests
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: Screen recordings of failed tests
+          path: cypress/videos/refapp-3.x

--- a/cypress.json
+++ b/cypress.json
@@ -4,7 +4,7 @@
     "*.feature",
     "**/*.feature"
   ],
-  "video": false,
+  "video": true,
   "defaultCommandTimeout": 120000,
   "baseUrl": "https://openmrs-spa.org/openmrs/spa",
   "env": {


### PR DESCRIPTION
## Purpose
The pull request is to add a new feature of attaching screen recording of failed 3. x tests and this pull request is related to the issue ticket number [RATEST-207](https://issues.openmrs.org/browse/RATEST-207).

## Goals
- To allow developers/stakeholders to identify why tests failing by playing the screen recording without running them locally. 
- To save time

## Approach
1. Make cypress screen recording facility turn on.
2. Make 3. x test GitHub workflows to attach the screen recordings of failed tests.

### Screenshots


#### Passed test

![image](https://user-images.githubusercontent.com/77311602/131487299-6a195e2c-a4f4-4e09-bbb1-bd067de0ed93.png)


#### Failed test

A failed test - ([Link](https://github.com/openmrs/openmrs-contrib-qaframework/actions/runs/1185617340))

![image](https://user-images.githubusercontent.com/77311602/131487179-93b7de69-df6e-4a8a-8bca-9c3d71340424.png)



