### PR TITLE
RATEST-211: Update the 3.x search workflow according to the new UI

### DIFF
--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/02-search-and-registration/search-and-registration.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/02-search-and-registration/search-and-registration.js
@@ -8,6 +8,9 @@ Given('the user login to the Registration Desk', () => {
 When('the user search for {string}', patientName => {
     cy.get('button[name=SearchPatientIcon]').click();
     cy.getByPlaceholder('Search for a patient by name or identifier number').type(patientName);
+//Adding an artificial wait because it takes time to get typed test updates
+    cy.wait(500);
+    cy.contains('Search').click({force:true});
 })
 
 Then('the result should be {string}', result => {


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix [RATEST-211](https://issues.openmrs.org/projects/RATEST/issues/RATEST-211?filter=allopenissues).

## Approach
Update the 3.x search and registration workflow to fix with the new user interface.
(Previously there was no search button. Now with a current UI, there is a search button to click to search patients.)

## ScreenShot
![image](https://user-images.githubusercontent.com/77311602/131729775-f17ebecc-c109-4e6b-8a9b-afb3129b29fa.png)
