### PR TITLE
RATEST-227: Adding beforeEach hook in login to register the event handler for the test

### DIFF
--- a/cypress/integration/cucumber/step_definitions/refapp-3.x/01-login/login.js
+++ b/cypress/integration/cucumber/step_definitions/refapp-3.x/01-login/login.js
@@ -1,10 +1,14 @@
 import {Given} from 'cypress-cucumber-preprocessor/steps';
 
-Given('user arrives at the login page', () => {
-    cy.visit('/login');
-})
+Before({tags: '@patient-involved'}, () => {
+    cy.on('uncaught:exception', (err, runnable) => {
+        console.log(err);
+        return false;
+    });
+    cy.visit('/login');    
+});
 
-When('the user logs in with {string} and {string} to the {string}', (username, password, location) => {
+Given('the user logs in with {string} and {string} to the {string}', (username, password, location) => {
     cy.getByLabel('Username').type(username)
     cy.contains('Continue').click({force: true});
     cy.getByLabel('Password').type(password)

--- a/src/test/resources/features/refapp-3.x/01-login/login.feature
+++ b/src/test/resources/features/refapp-3.x/01-login/login.feature
@@ -1,8 +1,8 @@
 Feature: User Login
 
+  @login
   Scenario Outline: User login to the dashboard
-    Given user arrives at the login page
-    When the user logs in with "<username>" and "<password>" to the "<location>"
+    Given the user logs in with "<username>" and "<password>" to the "<location>"
     Then the user should be "<ability>" to login
 
     Examples:


### PR DESCRIPTION
Ticket [ID](https://issues.openmrs.org/browse/RATEST-227)

Description -> 3.x RefApp workflow tests are failing due to an error, unhandled promise rejection