### PR TITLE
RATEST-232: Failure when validating the vital value of respiratory rate

### DIFF
--- a/src/test/java/org/openmrs/contrib/qaframework/automation/VitalsAndTriagingSteps.java
+++ b/src/test/java/org/openmrs/contrib/qaframework/automation/VitalsAndTriagingSteps.java
@@ -118,11 +118,11 @@ public class VitalsAndTriagingSteps extends Steps {
 				hasItem("Maximum: 230"));
 		patientCaptureVitalsPage.clearPatientPulse();
 		patientCaptureVitalsPage.setPulseField("78");
-		patientCaptureVitalsPage.setRespiratoryField("106");
+		patientCaptureVitalsPage.setRespiratoryField("1004");
 		assertThat(patientCaptureVitalsPage.getValidationErrors(),
 				hasItem("Maximum: 99"));
 		patientCaptureVitalsPage.clearPatientRespiratoryRate();
-		patientCaptureVitalsPage.setRespiratoryField("16");
+		patientCaptureVitalsPage.setRespiratoryField("14");
 		patientCaptureVitalsPage.setBloodPressureFields("120", "180");
 		assertThat(patientCaptureVitalsPage.getValidationErrors(),
 				hasItem("Maximum: 150"));

--- a/src/test/java/org/openmrs/contrib/qaframework/automation/VitalsAndTriagingSteps.java
+++ b/src/test/java/org/openmrs/contrib/qaframework/automation/VitalsAndTriagingSteps.java
@@ -118,11 +118,11 @@ public class VitalsAndTriagingSteps extends Steps {
 				hasItem("Maximum: 230"));
 		patientCaptureVitalsPage.clearPatientPulse();
 		patientCaptureVitalsPage.setPulseField("78");
-		patientCaptureVitalsPage.setRespiratoryField("1004");
+		patientCaptureVitalsPage.setRespiratoryField("106");
 		assertThat(patientCaptureVitalsPage.getValidationErrors(),
-				hasItem("Maximum: 999"));
+				hasItem("Maximum: 99"));
 		patientCaptureVitalsPage.clearPatientRespiratoryRate();
-		patientCaptureVitalsPage.setRespiratoryField("14");
+		patientCaptureVitalsPage.setRespiratoryField("16");
 		patientCaptureVitalsPage.setBloodPressureFields("120", "180");
 		assertThat(patientCaptureVitalsPage.getValidationErrors(),
 				hasItem("Maximum: 150"));


### PR DESCRIPTION
Ticket [ID](https://issues.openmrs.org/browse/RATEST-232)

Description -> Failure when validating the vital value of respiratory rate