### PR TITLE
RATEST-233: Make local instance have the same versions of modules as qa-refapp

### DIFF
--- a/docker/docker-compose-refqa.yml
+++ b/docker/docker-compose-refqa.yml
@@ -15,7 +15,7 @@ services:
       - "3306:3306"
 
   openmrs-referenceapplication:
-    image: openmrs/openmrs-reference-application-distro:demo
+    image: openmrs/openmrs-reference-application-distro:qa
     depends_on:
       - openmrs-referenceapplication-mysql
     ports:


### PR DESCRIPTION
Ticket [ID](https://issues.openmrs.org/browse/RATEST-233)

Description ->  Make local instance have the same versions of modules as qa-refapp