### PR TITLE
RATEST-238x: Update refappuitests version to 2.13.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>1.8</java.version>
         <cucumber.version>6.7.0</cucumber.version>
         <uitestframework.version>2.5.0-SNAPSHOT</uitestframework.version>
-        <refappuitests.version>2.12.0-SNAPSHOT</refappuitests.version>
+        <refappuitests.version>2.13.0-SNAPSHOT</refappuitests.version>
         <formatter.version>0.4</formatter.version>
     </properties>
     <dependencies>


### PR DESCRIPTION
Ticket [ID](https://issues.openmrs.org/browse/RATEST-238)

Description -> Continuous integration fails on both Github Actions and Bamboo when resolving dependency for the referenceapplication-ui-test module. See the full [logs](https://ci.openmrs.org/browse/CONTRIB-QA-883/log)