### PR TITLE
Adding visibility Element on ClickInActive in conditionsPage in the QA framework

### DIFF
--- a/src/test/java/org/openmrs/contrib/qaframework/page/ConditionsPage.java
+++ b/src/test/java/org/openmrs/contrib/qaframework/page/ConditionsPage.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.openmrs.contrib.qaframework.helper.Page;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class ConditionsPage extends Page {
 
@@ -50,6 +51,7 @@ public class ConditionsPage extends Page {
 
 	public String getFirstConditionName() {
 		try {
+			waiter.until(ExpectedConditions.elementToBeClickable(FIRST_CONDITION_NAME));
 			return driver.findElement(FIRST_CONDITION_NAME).getAttribute(
 					"innerText");
 		} catch (Exception e) {
@@ -62,6 +64,7 @@ public class ConditionsPage extends Page {
 	}
 
 	public void clickInActiveTab() {
+		waiter.until(ExpectedConditions.elementToBeClickable(TAB_INACTIVE));
 		clickOn(TAB_INACTIVE);
 	}
 


### PR DESCRIPTION
**TICKET ID**
https://issues.openmrs.org/browse/RATEST-256

**DESCRIPTION**
To add a visibility element on the `clickInActive()` method and `getFirstConditionName()` in conditions Page that was causing the build failures.

cc : @sherrif10 