### PR TITLE
RATEST-260: Remove headers from the static.json file

### DIFF
--- a/static.json
+++ b/static.json
@@ -9,10 +9,5 @@
     "/**": "index.html"
   },
   "clean_urls": true,
-  "https_only": true,
-  "headers": {
-    "/**": {
-      "Strict-Transport-Security": "max-age=31557600"
-    }
-  }
+  "https_only": true
 }


### PR DESCRIPTION
Ticket [ID](https://issues.openmrs.org/browse/RATEST-260)

Description -> Remove headers from the static.json file
The link provided by Heroku pipeline on a PR build plan returns `404 Not Found`.The link should redirect to deployment page of the PR.