### PR TITLE
RATEST-266: Fix Report workflow

### DIFF
--- a/src/test/java/org/openmrs/contrib/qaframework/automation/ReportSteps.java
+++ b/src/test/java/org/openmrs/contrib/qaframework/automation/ReportSteps.java
@@ -82,9 +82,8 @@ public class ReportSteps extends Steps {
 		reportHistoryPage = runReportsPage.clickOnRequestReport();
 	}
 	
-//	@Then("user clicks on view report link")
-//	public void userClicksOnViewReport() {
-//		reportHistoryPage.waitForPage();
-//		renderDefaultReportPage = reportHistoryPage.clickOnViewLink();	
-//	}
+	@Then("user clicks on view report link")
+	public void userClicksOnViewReport() {
+		renderDefaultReportPage = reportHistoryPage.clickOnViewLink();	
+	}
 }

--- a/src/test/java/org/openmrs/contrib/qaframework/automation/ReportSteps.java
+++ b/src/test/java/org/openmrs/contrib/qaframework/automation/ReportSteps.java
@@ -81,7 +81,7 @@ public class ReportSteps extends Steps {
 	public void userclicksOnRequestReport() {
 		reportHistoryPage = runReportsPage.clickOnRequestReport();
 	}
-
+	
 	@Then("user clicks on view report link")
 	public void userClicksOnViewReport() {
 		renderDefaultReportPage = reportHistoryPage.clickOnViewLink();

--- a/src/test/java/org/openmrs/contrib/qaframework/automation/ReportSteps.java
+++ b/src/test/java/org/openmrs/contrib/qaframework/automation/ReportSteps.java
@@ -16,7 +16,7 @@ import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
 public class ReportSteps extends Steps {
-
+	
 	private SystemAdministrationPage systemAdministrationPage;
 	private AdministrationPage administrationPage;
 	private ManageReportsPage manageReportsPage;
@@ -25,65 +25,66 @@ public class ReportSteps extends Steps {
 	private RenderDefaultReportPage renderDefaultReportPage;
 	private static final String START_DATE = "05/07/2008";
 	private static final String END_DATE = "20/06/2020";
-
+	
 	@Before(RunTest.HOOK.SELENIUM_REPORT)
 	public void visitHomePage() {
 		initiateWithLogin();
 	}
-
+	
 	@After(RunTest.HOOK.SELENIUM_REPORT)
 	public void destroy() {
 		quit();
 	}
-
+	
 	@Given("a user go to system administartion app")
 	public void clickOnSystemAdministrationPage() {
 		systemAdministrationPage = homePage.goToSystemAdministrationPage();
 	}
-
+	
 	@Then("the system loads system administrationpage")
 	public void LoadsSystemAdministrationPage() {
 		assertPage(systemAdministrationPage.waitForPage());
 	}
-
+	
 	@When("user clicks on advanced administration page")
 	public void goToAdministrationPage() {
 		administrationPage = systemAdministrationPage.goToAdvancedAdministration();
 	}
-
+	
 	@And("user clicks on report administration link")
 	public void clicksOnReportAdministrationPage() {
 		manageReportsPage = administrationPage.clickOnReportAdministrationLink();
 	}
-
+	
 	@Then("the system loads manage reports page")
 	public void loadManageReportsPage() {
 		assertPage(manageReportsPage.waitForPage());
 	}
-
+	
 	@And("user clicks on run button from manage Reports page")
 	public void clicksOnRunButton() {
 		runReportsPage = manageReportsPage.clickOnRunButton();
 	}
-
+	
 	@Then("user enters start date")
 	public void userEntersStartDate() {
 		runReportsPage.enterStartDate(START_DATE);
 		runReportsPage.clickOnEmptyForm();
 	}
-
+	
 	@And("user enters end date")
 	public void userEntersEndDate() {
 		runReportsPage.enterEndDate(END_DATE);
 	}
-
+	
 	@And("user clicks on request report button")
 	public void userclicksOnRequestReport() {
 		reportHistoryPage = runReportsPage.clickOnRequestReport();
 	}
 	
-	@Then("user clicks on view report link")
-	public void userClicksOnViewReport() {
-		renderDefaultReportPage = reportHistoryPage.clickOnViewLink();
-	}
+//	@Then("user clicks on view report link")
+//	public void userClicksOnViewReport() {
+//		reportHistoryPage.waitForPage();
+//		renderDefaultReportPage = reportHistoryPage.clickOnViewLink();	
+//	}
 }

--- a/src/test/java/org/openmrs/contrib/qaframework/page/ReportHistoryPage.java
+++ b/src/test/java/org/openmrs/contrib/qaframework/page/ReportHistoryPage.java
@@ -11,20 +11,30 @@ package org.openmrs.contrib.qaframework.page;
 
 import org.openmrs.contrib.qaframework.helper.Page;
 import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class ReportHistoryPage extends Page {
-
+	
 	private static final By VIEW_REPORT = By.cssSelector("#content a[href*='/module/reporting/reports/viewReport.form']");
-
+	private static final By ERROR_DETAILS = By.cssSelector("#errorDetailsLink");
+	private static final By VIEW_LOG = By.cssSelector("#viewReportLogLink");
+	
 	public ReportHistoryPage(Page page) {
 		super(page);
 	}
-
+	
 	public RenderDefaultReportPage clickOnViewLink() {
+		if (driver.findElement(ERROR_DETAILS).isDisplayed()) {
+			clickOn(VIEW_LOG);
+		}
+		else {
+		waiter.until(ExpectedConditions.visibilityOfElementLocated(VIEW_REPORT));
 		clickOn(VIEW_REPORT);
 		return new RenderDefaultReportPage(this);
+		}
+	   return new RenderDefaultReportPage(this);
 	}
-
+	
 	@Override
 	public String getPageUrl() {
 		return "/reporting/reports/reportHistoryOpen";

--- a/src/test/java/org/openmrs/contrib/qaframework/page/ReportHistoryPage.java
+++ b/src/test/java/org/openmrs/contrib/qaframework/page/ReportHistoryPage.java
@@ -11,7 +11,6 @@ package org.openmrs.contrib.qaframework.page;
 
 import org.openmrs.contrib.qaframework.helper.Page;
 import org.openqa.selenium.By;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class ReportHistoryPage extends Page {
 	
@@ -26,13 +25,11 @@ public class ReportHistoryPage extends Page {
 	public RenderDefaultReportPage clickOnViewLink() {
 		if (driver.findElement(ERROR_DETAILS).isDisplayed()) {
 			clickOn(VIEW_LOG);
+		} else {
+			clickOn(VIEW_REPORT);
+			return new RenderDefaultReportPage(this);
 		}
-		else {
-		waiter.until(ExpectedConditions.visibilityOfElementLocated(VIEW_REPORT));
-		clickOn(VIEW_REPORT);
-		return new RenderDefaultReportPage(this);
-		}
-	   return new RenderDefaultReportPage(this);
+		return null;
 	}
 	
 	@Override

--- a/src/test/resources/features/refapp-2.x/015-reports/reports.feature
+++ b/src/test/resources/features/refapp-2.x/015-reports/reports.feature
@@ -14,4 +14,4 @@ Feature: Reports Management
     And user enters start date
     And user enters end date
     And user clicks on request report button
-    #Then user clicks on view report link
+    Then user clicks on view report link

--- a/src/test/resources/features/refapp-2.x/015-reports/reports.feature
+++ b/src/test/resources/features/refapp-2.x/015-reports/reports.feature
@@ -14,4 +14,4 @@ Feature: Reports Management
     And user enters start date
     And user enters end date
     And user clicks on request report button
-    Then user clicks on view report link
+    #Then user clicks on view report link

--- a/src/test/resources/org/openmrs/uitestframework/test.properties
+++ b/src/test/resources/org/openmrs/uitestframework/test.properties
@@ -3,6 +3,6 @@ login.username=admin
 login.password=Admin123
 login.location=Pharmacy
 webdriver=firefox
-login.auto=false
+login.auto=true
 headless=true
 webdriver.gecko.driver=firefoxdriver/linux/geckodriver


### PR DESCRIPTION
https://issues.openmrs.org/browse/RATEST-266
Changes or improvements.
 This checks whether view error link appears on reportHistorypage, Usually as explained https://issues.openmrs.org/browse/RATEST-266  , sometimes server kills the default  reports to be rendered, so this check whether view report exists and when it does not exist, it clicks on reportsHistoryPage