### PR TITLE
O3-920: Add search workflow test result badge to the 3.X dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Install & Upgrade Tests |
 ------------- |
 [3.x Demo Build](https://ci.openmrs.org/browse/REFAPP-D3X) ![Build Status](https://ci.openmrs.org/plugins/servlet/wittified/build-status/REFAPP-D3X)
 [![RefApp 3.x Login](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-login.yml/badge.svg)](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-login.yml)
-[![RefApp 3.x Search & Registration](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-search-and-registration.yml/badge.svg)](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-search-and-registration.yml)
+[![RefApp 3.x Patient Registration](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-patient-registration.yml/badge.svg)](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-patient-registration.yml)
 [![RefApp 3.x User settings](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-settings.yml/badge.svg)](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-settings.yml)
 [![RefApp 3.x Clinical Visit](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-clinical-visit.yml/badge.svg)](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-clinical-visit.yml)
 [![RefApp 3.x Vitals And Triage](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-vitals-and-triage.yml/badge.svg)](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-vitals-and-triage.yml)
+[![RefApp 3.x Patient Search](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-patient-search.yml/badge.svg)](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-3x-patient-search.yml)
 ___
 
 ## Concept Management Tools 


### PR DESCRIPTION
# Purpose
The purpose of this PR is to fix [O3-920](https://issues.openmrs.org/browse/O3-920).

3.X dashboard should be updated to showcase the test result of the newly created patient-search workflow.

# Approach
Update the dashboard to showcase the patient-search work test result badge.