### PR TITLE
O3-897: Configure cypress retries to retry failing E2E tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -19,9 +19,7 @@
   "viewportHeight": 900,
 
   "retries": {
-    // Configure retry attempts for `cypress run`
     "runMode": 2,
-    // Configure retry attempts for `cypress open`
     "openMode": 0
   }
 }

--- a/cypress.json
+++ b/cypress.json
@@ -16,5 +16,12 @@
     "DEFAULT_LOCATION_NAME": "Registration Desk"
   },
   "viewportWidth": 1800,
-  "viewportHeight": 900
+  "viewportHeight": 900,
+
+  "retries": {
+    // Configure retry attempts for `cypress run`
+    "runMode": 2,
+    // Configure retry attempts for `cypress open`
+    "openMode": 0
+  }
 }


### PR DESCRIPTION
## Purpose
The pull request is to fix -
Issue ticket [O3-897](https://issues.openmrs.org/browse/O3-897)

## Goals
Create cypress run mode retries to retry failing E2E tests. 

## Approach
1. Create cypress retries in cypress configuration file
2. Increase runMode count to retry the failing tests.
