### PR TITLE
O3-895: Update E2E workflows to generate a cucumber report

### DIFF
--- a/.github/workflows/refapp-3x-clinical-visit.yml
+++ b/.github/workflows/refapp-3x-clinical-visit.yml
@@ -22,7 +22,7 @@ jobs:
         run: cd qaframework-bdd-tests
       - name: Run clinical visit workflow tests
         run: |
-          echo "cucumber.publish.enabled=true" > src/test/resources/cucumber.properties
+          echo "cucumber.publish.enabled=true" > qaframework-bdd-tests/src/test/resources/cucumber.properties
           npm run refapp3ClinicalVisit
           curl -sX POST -F messages=@target/cucumber.ndjson https://studio.cucumber.io/cucumber_project/results -H "project-access-token: ${{secrets.CUCUMBER_IO_TOKEN}}" -H "provider: github" -H "repo: ${{github.repository}}" -H "branch: master" -H "revision: ${{github.sha}}"
       - name: Upload screen recordings of failed tests
@@ -30,4 +30,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Screen recordings of failed tests
-          path: cypress/videos/refapp-3.x
+          path: qaframework-bdd-tests/cypress/videos/refapp-3.x

--- a/.github/workflows/refapp-3x-clinical-visit.yml
+++ b/.github/workflows/refapp-3x-clinical-visit.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Navigate into qaframework-bdd-tests
         run: cd qaframework-bdd-tests
       - name: Run clinical visit workflow tests
-        run: npm run refapp3ClinicalVisit
+        run: |
+          echo "cucumber.publish.enabled=true" > src/test/resources/cucumber.properties
+          npm run refapp3ClinicalVisit
+          curl -sX POST -F messages=@target/cucumber.ndjson https://studio.cucumber.io/cucumber_project/results -H "project-access-token: ${{secrets.CUCUMBER_IO_TOKEN}}" -H "provider: github" -H "repo: ${{github.repository}}" -H "branch: master" -H "revision: ${{github.sha}}"
       - name: Upload screen recordings of failed tests
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/refapp-3x-login.yml
+++ b/.github/workflows/refapp-3x-login.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Navigate into qaframework-bdd-tests
         run: cd qaframework-bdd-tests
       - name: Run login workflow tests
-        run: npm run refapp3Login
+        run: |
+          echo "cucumber.publish.enabled=true" > src/test/resources/cucumber.properties
+          npm run refapp3Login
+          curl -sX POST -F messages=@target/cucumber.ndjson https://studio.cucumber.io/cucumber_project/results -H "project-access-token: ${{secrets.CUCUMBER_IO_TOKEN}}" -H "provider: github" -H "repo: ${{github.repository}}" -H "branch: master" -H "revision: ${{github.sha}}"
       - name: Upload screen recordings of failed tests
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/refapp-3x-login.yml
+++ b/.github/workflows/refapp-3x-login.yml
@@ -22,7 +22,7 @@ jobs:
         run: cd qaframework-bdd-tests
       - name: Run login workflow tests
         run: |
-          echo "cucumber.publish.enabled=true" > src/test/resources/cucumber.properties
+          echo "cucumber.publish.enabled=true" > qaframework-bdd-tests/src/test/resources/cucumber.properties
           npm run refapp3Login
           curl -sX POST -F messages=@target/cucumber.ndjson https://studio.cucumber.io/cucumber_project/results -H "project-access-token: ${{secrets.CUCUMBER_IO_TOKEN}}" -H "provider: github" -H "repo: ${{github.repository}}" -H "branch: master" -H "revision: ${{github.sha}}"
       - name: Upload screen recordings of failed tests
@@ -30,4 +30,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Screen recordings of failed tests
-          path: cypress/videos/refapp-3.x
+          path: qaframework-bdd-tests/cypress/videos/refapp-3.x

--- a/.github/workflows/refapp-3x-patient-registration.yml
+++ b/.github/workflows/refapp-3x-patient-registration.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Navigate into qaframework-bdd-tests
         run: cd qaframework-bdd-tests
       - name: Run patient registration workflow tests
-        run: npm run refapp3PatientRegistration
+        run: |
+          echo "cucumber.publish.enabled=true" > src/test/resources/cucumber.properties
+          npm run refapp3PatientRegistration
+          curl -sX POST -F messages=@target/cucumber.ndjson https://studio.cucumber.io/cucumber_project/results -H "project-access-token: ${{secrets.CUCUMBER_IO_TOKEN}}" -H "provider: github" -H "repo: ${{github.repository}}" -H "branch: master" -H "revision: ${{github.sha}}"
       - name: Upload screen recordings of failed tests
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/refapp-3x-patient-registration.yml
+++ b/.github/workflows/refapp-3x-patient-registration.yml
@@ -22,7 +22,7 @@ jobs:
         run: cd qaframework-bdd-tests
       - name: Run patient registration workflow tests
         run: |
-          echo "cucumber.publish.enabled=true" > src/test/resources/cucumber.properties
+          echo "cucumber.publish.enabled=true" > qaframework-bdd-tests/src/test/resources/cucumber.properties
           npm run refapp3PatientRegistration
           curl -sX POST -F messages=@target/cucumber.ndjson https://studio.cucumber.io/cucumber_project/results -H "project-access-token: ${{secrets.CUCUMBER_IO_TOKEN}}" -H "provider: github" -H "repo: ${{github.repository}}" -H "branch: master" -H "revision: ${{github.sha}}"
       - name: Upload screen recordings of failed tests
@@ -30,4 +30,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Screen recordings of failed tests
-          path: cypress/videos/refapp-3.x
+          path: qaframework-bdd-tests/cypress/videos/refapp-3.x

--- a/.github/workflows/refapp-3x-patient-search.yml
+++ b/.github/workflows/refapp-3x-patient-search.yml
@@ -22,7 +22,7 @@ jobs:
         run: cd qaframework-bdd-tests
       - name: Run patient search workflow tests
         run: |
-          echo "cucumber.publish.enabled=true" > src/test/resources/cucumber.properties
+          echo "cucumber.publish.enabled=true" > qaframework-bdd-tests/src/test/resources/cucumber.properties
           npm run refapp3PatientSearch
           curl -sX POST -F messages=@target/cucumber.ndjson https://studio.cucumber.io/cucumber_project/results -H "project-access-token: ${{secrets.CUCUMBER_IO_TOKEN}}" -H "provider: github" -H "repo: ${{github.repository}}" -H "branch: master" -H "revision: ${{github.sha}}"
       - name: Upload screen recordings of failed tests
@@ -30,4 +30,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Screen recordings of failed tests
-          path: cypress/videos/refapp-3.x
+          path: qaframework-bdd-tests/cypress/videos/refapp-3.x

--- a/.github/workflows/refapp-3x-patient-search.yml
+++ b/.github/workflows/refapp-3x-patient-search.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Navigate into qaframework-bdd-tests
         run: cd qaframework-bdd-tests
       - name: Run patient search workflow tests
-        run: npm run refapp3PatientSearch
+        run: |
+          echo "cucumber.publish.enabled=true" > src/test/resources/cucumber.properties
+          npm run refapp3PatientSearch
+          curl -sX POST -F messages=@target/cucumber.ndjson https://studio.cucumber.io/cucumber_project/results -H "project-access-token: ${{secrets.CUCUMBER_IO_TOKEN}}" -H "provider: github" -H "repo: ${{github.repository}}" -H "branch: master" -H "revision: ${{github.sha}}"
       - name: Upload screen recordings of failed tests
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/refapp-3x-settings.yml
+++ b/.github/workflows/refapp-3x-settings.yml
@@ -22,7 +22,7 @@ jobs:
         run: cd qaframework-bdd-tests
       - name: Run User settings workflow tests
         run: |
-          echo "cucumber.publish.enabled=true" > src/test/resources/cucumber.properties
+          echo "cucumber.publish.enabled=true" > qaframework-bdd-tests/src/test/resources/cucumber.properties
           npm run refapp3Settings
           curl -sX POST -F messages=@target/cucumber.ndjson https://studio.cucumber.io/cucumber_project/results -H "project-access-token: ${{secrets.CUCUMBER_IO_TOKEN}}" -H "provider: github" -H "repo: ${{github.repository}}" -H "branch: master" -H "revision: ${{github.sha}}"
       - name: Upload screen recordings of failed tests
@@ -30,4 +30,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Screen recordings of failed tests
-          path: cypress/videos/refapp-3.x
+          path: qaframework-bdd-tests/cypress/videos/refapp-3.x

--- a/.github/workflows/refapp-3x-settings.yml
+++ b/.github/workflows/refapp-3x-settings.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Navigate into qaframework-bdd-tests
         run: cd qaframework-bdd-tests
       - name: Run User settings workflow tests
-        run: npm run refapp3Settings
+        run: |
+          echo "cucumber.publish.enabled=true" > src/test/resources/cucumber.properties
+          npm run refapp3Settings
+          curl -sX POST -F messages=@target/cucumber.ndjson https://studio.cucumber.io/cucumber_project/results -H "project-access-token: ${{secrets.CUCUMBER_IO_TOKEN}}" -H "provider: github" -H "repo: ${{github.repository}}" -H "branch: master" -H "revision: ${{github.sha}}"
       - name: Upload screen recordings of failed tests
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/refapp-3x-vitals-and-triage.yml
+++ b/.github/workflows/refapp-3x-vitals-and-triage.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Navigate into qaframework-bdd-tests
         run: cd qaframework-bdd-tests
       - name: Run vitals and triage workflow tests
-        run: npm run refapp3VitalsAndTriage
+        run: |
+          echo "cucumber.publish.enabled=true" > src/test/resources/cucumber.properties
+          npm run refapp3VitalsAndTriage
+          curl -sX POST -F messages=@target/cucumber.ndjson https://studio.cucumber.io/cucumber_project/results -H "project-access-token: ${{secrets.CUCUMBER_IO_TOKEN}}" -H "provider: github" -H "repo: ${{github.repository}}" -H "branch: master" -H "revision: ${{github.sha}}"
       - name: Upload screen recordings of failed tests
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2

--- a/.github/workflows/refapp-3x-vitals-and-triage.yml
+++ b/.github/workflows/refapp-3x-vitals-and-triage.yml
@@ -22,7 +22,7 @@ jobs:
         run: cd qaframework-bdd-tests
       - name: Run vitals and triage workflow tests
         run: |
-          echo "cucumber.publish.enabled=true" > src/test/resources/cucumber.properties
+          echo "cucumber.publish.enabled=true" > qaframework-bdd-tests/src/test/resources/cucumber.properties
           npm run refapp3VitalsAndTriage
           curl -sX POST -F messages=@target/cucumber.ndjson https://studio.cucumber.io/cucumber_project/results -H "project-access-token: ${{secrets.CUCUMBER_IO_TOKEN}}" -H "provider: github" -H "repo: ${{github.repository}}" -H "branch: master" -H "revision: ${{github.sha}}"
       - name: Upload screen recordings of failed tests
@@ -30,4 +30,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Screen recordings of failed tests
-          path: cypress/videos/refapp-3.x
+          path: qaframework-bdd-tests/cypress/videos/refapp-3.x


### PR DESCRIPTION
## Purpose
The pull request is to fix -
Issue ticket [O3-895](https://issues.openmrs.org/browse/O3-895)

## Goals
Generate cucumber reports for E2E workflows

## Approach
1. Enable cucumber to store the test results in cucumber.properties in each 3.X workflows.
2. Create a script that will publish the result to cucumber studio
