### PR TITLE
RATEST: Remove the formatter version since the plugin no longer exists

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <cucumber.version>6.7.0</cucumber.version>
-        <formatter.version>0.4</formatter.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Goal:
Get rid of the formatter version since the plugin no longer exists