### PR TITLE
O3-993 : Fix RefApp 3.x login E2E test

### DIFF
--- a/.github/workflows/refapp-3x-login.yml
+++ b/.github/workflows/refapp-3x-login.yml
@@ -1,15 +1,18 @@
 name: RefApp 3.x Login
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
   repository_dispatch:
-    types: [qa]
+    types: [ qa ]
   workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./qaframework-bdd-tests
     steps:
       - uses: actions/checkout@v2
       - name: Using Node.js
@@ -18,8 +21,6 @@ jobs:
           node-version: '12.x'
       - name: Installing dependencies
         run: npm install
-      - name: Navigate into qaframework-bdd-tests
-        run: cd qaframework-bdd-tests
       - name: Run login workflow tests
         run: npm run refapp3Login
       - name: Upload screen recordings of failed tests
@@ -27,4 +28,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Screen recordings of failed tests
-          path: cypress/videos/refapp-3.x
+          path: qaframework-bdd-tests/cypress/videos/refapp-3.x

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,8 @@ qaframework.iml
 target/
 node/
 package-lock.json
-cypress/screenshots
-cypress/videos
+qaframework-bdd-tests/cypress/screenshots
+qaframework-bdd-tests/cypress/videos
 node_modules/
 openmrs.log
 .classpath

--- a/qaframework-bdd-tests/cypress.json
+++ b/qaframework-bdd-tests/cypress.json
@@ -9,9 +9,9 @@
   "baseUrl": "https://openmrs-spa.org/openmrs/spa",
   "env": {
     "API_BASE_URL": "https://openmrs-spa.org/openmrs/ws/rest/v1",
-    "ADMIN_USERNAME": "spa_user",
+    "ADMIN_USERNAME": "admin2",
     "ADMIN_PASSWORD": "Admin123",
-    "ADMIN_UUID": "8f24ac87-2d71-4574-991e-97803e6f8095",
+    "ADMIN_UUID": "fbd7a058-88c4-4747-b572-32aaf8ef6ac9",
     "DEFAULT_LOCATION_UUID": "6351fcf4-e311-4a19-90f9-35667d99a8af",
     "DEFAULT_LOCATION_NAME": "Registration Desk",
     "OCL_USER_TOKEN": "",

--- a/qaframework-bdd-tests/src/test/resources/features/refapp-3.x/01-login/login.feature
+++ b/qaframework-bdd-tests/src/test/resources/features/refapp-3.x/01-login/login.feature
@@ -7,6 +7,6 @@ Feature: User Login
 
     Examples:
       | username   | password   | location          | ability |
-      | admin      | Admin123   | Registration Desk | able    |
+      | admin2     | Admin123   | Registration Desk | able    |
       | wrong user | Admin123   | Registration Desk | unable  |
-      | admin      | wrong pass | Registration Desk | unable  |
+      | admin2     | wrong pass | Registration Desk | unable  |


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix [O3-993](https://issues.openmrs.org/browse/O3-993)

## Goals
Fix the failing login E2E test.

## Approach
Update relevant cypress environment variables.
Updated the login E2E test and workflow

## Screenshots
![image](https://user-images.githubusercontent.com/77311602/148806828-dae27306-dd3e-4996-a1c7-fb52f19e0885.png)

Note: The error message with the wrong login details is not shown in the UI. Because of it 2 of 3 tests are failing.