### PR TITLE
O3-984: Fix RefApp 3.x Clinical Visit E2E Test

### DIFF
--- a/qaframework-bdd-tests/cypress.json
+++ b/qaframework-bdd-tests/cypress.json
@@ -5,7 +5,7 @@
     "**/*.feature"
   ],
   "video": true,
-  "defaultCommandTimeout": 20000,
+  "defaultCommandTimeout": 120000,
   "baseUrl": "https://openmrs-spa.org/openmrs/spa",
   "env": {
     "API_BASE_URL": "https://openmrs-spa.org/openmrs/ws/rest/v1",

--- a/qaframework-bdd-tests/cypress/integration/cucumber/step_definitions/refapp-3.x/04-clinical-visit/clinical-visit.js
+++ b/qaframework-bdd-tests/cypress/integration/cucumber/step_definitions/refapp-3.x/04-clinical-visit/clinical-visit.js
@@ -41,11 +41,12 @@ Then('the user should be able to expand header to see more information', () => {
 Then('the Patient Summary should load properly', () => {
     cy.get('div[data-extension-slot-name="patient-chart-summary-dashboard-slot"]').contains('Care Programs');
     cy.get('div[data-extension-slot-name="patient-chart-summary-dashboard-slot"]').contains('Active Medications');
+    cy.get('div[data-extension-slot-name="patient-chart-summary-dashboard-slot"]').contains('Recent Results');
     cy.get('div[data-extension-slot-name="patient-chart-summary-dashboard-slot"]').contains('Biometrics');
     cy.get('div[data-extension-slot-name="patient-chart-summary-dashboard-slot"]').contains('Vitals');
     cy.get('div[data-extension-slot-name="patient-chart-summary-dashboard-slot"]').contains('Forms');
     cy.get('div[data-extension-slot-name="patient-chart-summary-dashboard-slot"]').contains('Conditions');
-    cy.get('div[data-extension-slot-name="patient-chart-summary-dashboard-slot"]').contains('Notes');
+    cy.get('div[data-extension-slot-name="patient-chart-summary-dashboard-slot"]').contains('Visit notes');
     cy.get('div[data-extension-slot-name="patient-chart-summary-dashboard-slot"]').contains('Appointments');
     cy.get('div[data-extension-slot-name="patient-chart-summary-dashboard-slot"]').contains('Allergies');
     cy.get('div[data-extension-slot-name="patient-chart-summary-dashboard-slot"]').contains('Immunizations');
@@ -57,11 +58,11 @@ When('the user clicks on {string} in the menu', (menu) => {
 });
 
 Then('the program list should be empty', () => {
-    cy.contains('There are no program enrollments to display for this patient');
+    cy.contains('There are no programs to display for this patient');
 });
 
 When('the user enrolls the patient into a program', () => {
-    cy.contains('Record program enrollments').click();
+    cy.contains('Record programs').click();
     cy.get('#program').select('HIV Care and Treatment');
     cy.get('button[type="submit"').click();
 });
@@ -89,7 +90,6 @@ When('the user adds an allergy', () => {
 
 Then('the added allergy should be listed', () => {
     cy.contains('Allergy saved');
-    cy.reload();
     cy.contains('ACE inhibitors');
 });
 
@@ -106,7 +106,6 @@ When('the user adds a condition', () => {
 
 Then('the added condition should be listed', () => {
     cy.contains('Condition saved successfully');
-    cy.reload();
     cy.contains('Fever');
 });
 
@@ -133,11 +132,11 @@ Then('the trend line should be shown', () => {
 })
 
 When('the user changes the time range of a trend line', () => {
-    cy.contains('5 days').click({force: true});
+    cy.contains('5 years').click({force: true});
 })
 
 Then('the time range of the trend line should be changed', () => {
-    cy.contains('Jan 20');
+    cy.contains('2017');
 })
 
 Then('the form entry widget should load properly', () => {
@@ -161,15 +160,15 @@ Then('the forms list should load properly', () => {
 });
 
 When('the user completes a form', () => {
-    cy.contains('Record Vitals').click({force: true});
-    cy.get('#Temperature').type("38");
-    cy.contains('Sign & Save').click({force: true});
+    cy.contains('POC CES Consult Note').click({force: true});
+    cy.get('textarea').type('Filled', {force: true});
+    cy.contains('Save').click({force: true});
+    cy.contains('The form has been submitted successfully');
+    cy.reload();
 });
 
 Then('the completed form should be listed', () => {
-    cy.contains('Vitals and Biometrics saved');
-    cy.reload();
-    cy.get('div[data-extension-id="patient-form-dashboard"]').contains('Vitals');
+    cy.get('div[data-extension-id="patient-form-dashboard"]').contains('POC CES Consult Note');
 });
 
 After({tags: '@clinical-visit'}, () => {

--- a/qaframework-bdd-tests/src/test/resources/features/refapp-3.x/04-clinical-visit/clinical-visit.feature
+++ b/qaframework-bdd-tests/src/test/resources/features/refapp-3.x/04-clinical-visit/clinical-visit.feature
@@ -14,7 +14,7 @@ Feature: Clinical Visit
     Then the Patient Summary should load properly
 
   @clinical-visit
-  Scenario: The programs page should function properly
+  Scenario: The Programs page should function properly
     When the user clicks on "Programs" in the menu
     Then the program list should be empty
     When the user enrolls the patient into a program
@@ -46,8 +46,8 @@ Feature: Clinical Visit
     Then the time range of the trend line should be changed
 
   @clinical-visit
-  Scenario: The Form Entry page should function properly
-    When the user clicks on "Form Entry" in the menu
+  Scenario: The Forms & Notes page should function properly
+    When the user clicks on "Forms & Notes" in the menu
     Then the form entry widget should load properly
     When the user clicks on "Recommended" in the form widget
     Then the forms list should be empty
@@ -56,4 +56,5 @@ Feature: Clinical Visit
     When the user clicks on "All" in the form widget
     Then the forms list should load properly
     When the user completes a form
+    And  the user clicks on "Completed" in the form widget
     Then the completed form should be listed


### PR DESCRIPTION
## Purpose
The purpose of this PR is to fix [O3-984](https://issues.openmrs.org/browse/O3-984)

## Goals
Fix the failing clinical visit tests

## Approach
- Updated the Clinical Visit E2E test
- Increased the default timeout to 120 sec
  - It takes around 115 seconds to load the patient dashboard if we reload the page during a test. In the form entry and programs UI, the new data doesn't appear unless we refresh it. So it's not possible to remove the reload function at the moment.
  -  Also the test consumes around 850MB when running, because it downloads all the modules before displaying the UI (due to the offline mode).

## Screenshots
![image](https://user-images.githubusercontent.com/27498587/150125932-bc562e70-0bbc-4e10-8122-5f53a0e1ad33.png)
