### PR TITLE
Dockerize All the Workflows To Use Latest Standalone Driver Images

### DIFF
--- a/.github/workflows/ocl-subscription-module.yml
+++ b/.github/workflows/ocl-subscription-module.yml
@@ -18,10 +18,12 @@ jobs:
           node-version: '12.x'
       - name: Installing dependencies
         run: npm install
-      - name: run db and web containers
-        run: |
-          cd docker
-          docker-compose -f docker-compose-refqa.yml up -d
+      - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash    
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Navigate into qaframework-bdd-tests

--- a/.github/workflows/refapp-2x-clinical-visit.yml
+++ b/.github/workflows/refapp-2x-clinical-visit.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+          - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-condition.yml
+++ b/.github/workflows/refapp-2x-condition.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+           - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-find-Patient.yml
+++ b/.github/workflows/refapp-2x-find-Patient.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+         - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-form.yml
+++ b/.github/workflows/refapp-2x-form.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+       - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-inpatient.yml
+++ b/.github/workflows/refapp-2x-inpatient.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+     - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-legacy.yml
+++ b/.github/workflows/refapp-2x-legacy.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+     - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-patient-allergies.yml
+++ b/.github/workflows/refapp-2x-patient-allergies.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+      - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-patient-demographics.yml
+++ b/.github/workflows/refapp-2x-patient-demographics.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+     - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-person.yml
+++ b/.github/workflows/refapp-2x-person.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+       - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-provider.yml
+++ b/.github/workflows/refapp-2x-provider.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+      - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-registration.yml
+++ b/.github/workflows/refapp-2x-registration.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+      - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-report.yml
+++ b/.github/workflows/refapp-2x-report.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+      - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-roles-and-privileges.yml
+++ b/.github/workflows/refapp-2x-roles-and-privileges.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+        - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-user-account.yml
+++ b/.github/workflows/refapp-2x-user-account.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+      - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/.github/workflows/refapp-2x-vitals-and-triaging.yml
+++ b/.github/workflows/refapp-2x-vitals-and-triaging.yml
@@ -25,9 +25,12 @@ jobs:
         uses: actions/checkout@master
         with:
           repository: ${{github.repository}}
-      - name: run db and web containers
-        run: |
-          docker-compose -f docker/docker-compose-refqa.yml up -d
+      - name:  Start the Remote web driver in docker  
+        run:  |
+              docker-compose up -d chrome
+      - name: Sleep for 3 minutes 
+        run: sleep 3m
+        shell: bash 
       - name: wait for openmrs instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 1; done
       - name: Run qaframework on selenium

--- a/qaframework-bdd-tests/docker-compose.yml
+++ b/qaframework-bdd-tests/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.3"
+services:
+  chrome:
+    image: selenium/standalone-chrome
+    hostname: chrome
+    container_name: chrome
+    ports:
+      - "4444:4444"
+      - "7900:7900"
+
+  firefox:
+    image: selenium/standalone-firefox
+    hostname: firefox
+    container_name: firefox
+    ports:
+      - "4445:4444"
+      - "7901:7900"

--- a/qaframework-bdd-tests/src/main/java/org/openmrs/contrib/qaframework/helper/TestProperties.java
+++ b/qaframework-bdd-tests/src/main/java/org/openmrs/contrib/qaframework/helper/TestProperties.java
@@ -15,6 +15,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.Properties;
 
+
 /**
  * Exposes test properties. This class is typically used like this:
  * TestProperties properties = TestProperties.instance();
@@ -30,6 +31,10 @@ import java.util.Properties;
  * &lt;/properties&gt;
  */
 public class TestProperties {
+
+	public static final String WEBDRIVER_TYPE_PROPERTY = "webdriver.type";
+
+	public static final String DEFAULT_WEBDRIVER_TYPE = "remote";
 
 	public static final String WEBDRIVER_PROPERTY = "webdriver";
 
@@ -116,11 +121,43 @@ public class TestProperties {
 		return getProperty(WEBDRIVER_PROPERTY, DEFAULT_WEBDRIVER);
 	}
 
+	public String getDriver() {
+		return getProperty(WEBDRIVER_TYPE_PROPERTY, DEFAULT_WEBDRIVER_TYPE);
+	}
+
 	public WebDriverType getWebDriver() {
 		try {
 			return WebDriverType.valueOf(getBrowser());
 		} catch (IllegalArgumentException e) {
-			return WebDriverType.firefox;
+			return WebDriverType.remote;
+		}
+	}
+
+	public enum BrowserType {
+		chrome,
+		firefox
+	}
+
+	public enum WebDriverType {
+		remote,
+		local
+	}
+
+	public BrowserType getBrowserType() {
+		try {
+			return BrowserType.valueOf(getBrowser());
+		}
+		catch (IllegalArgumentException e) {
+			return BrowserType.firefox;
+		}
+	}
+
+	public WebDriverType getDriverType() {
+		try {
+			return WebDriverType.valueOf(getDriver());
+		}
+		catch (IllegalArgumentException e) {
+			return WebDriverType.remote;
 		}
 	}
 
@@ -140,9 +177,5 @@ public class TestProperties {
 
 	public String getFirefoxDriverLocation() {
 		return getProperty("webdriver.gecko.driver", null);
-	}
-
-	public enum WebDriverType {
-		chrome, firefox
 	}
 }

--- a/qaframework-bdd-tests/src/test/resources/org/openmrs/uitestframework/test-local.properties
+++ b/qaframework-bdd-tests/src/test/resources/org/openmrs/uitestframework/test-local.properties
@@ -3,6 +3,8 @@ login.username=admin
 login.password=Admin123
 login.location=Pharmacy
 webdriver=firefox
+#remote/local
+webdriver.type=remote
 login.auto=false
 headless=true
 db.host=openmrs

--- a/qaframework-bdd-tests/src/test/resources/org/openmrs/uitestframework/test.properties
+++ b/qaframework-bdd-tests/src/test/resources/org/openmrs/uitestframework/test.properties
@@ -2,6 +2,8 @@ webapp.url=https://qa-refapp.openmrs.org/openmrs
 login.username=admin
 login.password=Admin123
 login.location=Pharmacy
+#remote/local
+webdriver.type=remote
 webdriver=chrome
 login.auto=true
 headless=true


### PR DESCRIPTION
https://issues.openmrs.org/browse/RATEST-306
The idea behind this changes is that, its not very well stable and practical to keep changing the web drivers each time they are upgraded. 

so if there could be a way to allow drivers gets spinned up locally(using the default browser you are running) or using default browser the ci is running, This is the idea of introducing docker to keep updating selenium images and spin up the workflows smoothly.