### PR TITLE
O3-1030: Update E2E 3.x Login test case error message

### DIFF
--- a/qaframework-bdd-tests/cypress/integration/cucumber/step_definitions/refapp-3.x/01-login/login.js
+++ b/qaframework-bdd-tests/cypress/integration/cucumber/step_definitions/refapp-3.x/01-login/login.js
@@ -31,7 +31,7 @@ Then('the user should be {string} to login', (ability) => {
             cy.url().should('include', '/home');
             break;
         case "unable":
-            cy.contains("Incorrect username or password");
+            cy.contains("Invalid username or password");
             break;
         default:
             throw new Error(`Ability '${ability}' is not supported`);


### PR DESCRIPTION
## Purpose
The pull request is to fix the 3. x login tests case and this pull request is related to the issue ticket number [O3-1030](https://issues.openmrs.org/browse/O3-1030).

## Approach
Updated the error message in the login to fit with the new UI validation message.

### Screenshots


#### Passed test

![image](https://user-images.githubusercontent.com/77311602/151312718-8338c9e0-1e19-4996-8fc4-c23f3d03f928.png)


