### PR TITLE
RATEST: Fix the RefApp 2.x tests failing github actions

### DIFF
--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/AllergiesSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/AllergiesSteps.java
@@ -37,8 +37,8 @@ public class AllergiesSteps extends Steps {
 
 	@Before(RunTest.HOOK.SELENIUM_ALLERGIES)
 	public void visitDashboard() {
-		testPatient = createTestPatient();
 		initiateWithLogin();
+		testPatient = createTestPatient();
 		findPatientPage = homePage.goToFindPatientRecord();
 		findPatientPage.enterPatient(testPatient.identifier);
 		findPatientPage.waitForPageToLoad();

--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/ClinicalVisitSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/ClinicalVisitSteps.java
@@ -55,8 +55,8 @@ public class ClinicalVisitSteps extends Steps {
 
 	@Before(RunTest.HOOK.SELENIUM_CLINICAL_VISIT)
 	public void visitHomePage() {
-		testPatient = createTestPatient();
 		initiateWithLogin();
+		testPatient = createTestPatient();
 		new TestData.TestVisit(testPatient.uuid, TestData.getAVisitType(), getLocationUuid(homePage)).create();
 	}
 

--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/ConditionsSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/ConditionsSteps.java
@@ -33,9 +33,9 @@ public class ConditionsSteps extends Steps {
     private TestData.PatientInfo testPatient;
 
     @Before(RunTest.HOOK.SELENIUM_CONDITION)
-    public void visitDashboard() {
-        testPatient = createTestPatient();
+    public void visitDashboard() {     
         initiateWithLogin();
+        testPatient = createTestPatient();
         findPatientPage = homePage.goToFindPatientRecord();
         findPatientPage.enterPatient(testPatient.identifier);
         dashboardPage = findPatientPage.clickOnFirstPatient();

--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/FindPatientSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/FindPatientSteps.java
@@ -27,9 +27,9 @@ public class FindPatientSteps extends Steps {
 	private TestData.PatientInfo testPatient;
 
 	@Before(RunTest.HOOK.SELENIUM_FIND_PATIENT)
-	public void systemLogin() {
-		testPatient = createTestPatient();
+	public void systemLogin() {	
 		initiateWithLogin();
+		testPatient = createTestPatient();
 	}
 
 	@After(RunTest.HOOK.SELENIUM_FIND_PATIENT)

--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/InpatientSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/InpatientSteps.java
@@ -29,8 +29,8 @@ public class InpatientSteps extends Steps {
 
 	@Before(RunTest.HOOK.SELENIUM_ENCOUNTER)
 	public void visitHomePage() {
-		testPatient = createTestPatient();
 		initiateWithLogin();
+		testPatient = createTestPatient();
 	}
 
 	@After(RunTest.HOOK.SELENIUM_ENCOUNTER)

--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/VitalsAndTriagingSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/VitalsAndTriagingSteps.java
@@ -35,8 +35,8 @@ public class VitalsAndTriagingSteps extends Steps {
 
 	@Before(RunTest.HOOK.SELENIUM_VITALS)
 	public void visitPatientDashboard() {
-		testPatient = createTestPatient();
 		initiateWithLogin();
+		testPatient = createTestPatient();
 		findPatientPage = (FindPatientPage) homePage.goToFindPatientRecord().waitForPage();
 		findPatientPage.enterPatient(testPatient.identifier);
 		findPatientPage.waitForPageToLoad();


### PR DESCRIPTION
Creation of test patient should be invoked after the test logged into the system. However, these tests in context are failing with actions but passing with bamboo. cc: @sherrif10 