### PR TITLE
O3-1057 Move User Settings E2E test to the dockerized environment

### DIFF
--- a/.github/workflows/refapp-3x-settings.yml
+++ b/.github/workflows/refapp-3x-settings.yml
@@ -1,9 +1,9 @@
 name: RefApp 3.x User Settings
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dockerize-3.x ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dockerize-3.x ]
   repository_dispatch:
     types: [ qa ]
   workflow_dispatch:

--- a/.github/workflows/refapp-3x-settings.yml
+++ b/.github/workflows/refapp-3x-settings.yml
@@ -14,7 +14,14 @@ jobs:
       run:
         working-directory: ./qaframework-bdd-tests
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout qaframework
+        uses: actions/checkout@master
+        with:
+          repository: ${{github.repository}}
+      - name: Run db and web containers
+        run: docker-compose -f docker/docker-compose-refqa-3x.yml up -d
+      - name: Wait for Openmrs instance to start
+        run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost/openmrs/spa/settings)" != "200" ]]; do sleep 2; done
       - name: Using Node.js
         uses: actions/setup-node@v1
         with:

--- a/qaframework-bdd-tests/cypress/integration/cucumber/step_definitions/refapp-3.x/03-settings/settings.js
+++ b/qaframework-bdd-tests/cypress/integration/cucumber/step_definitions/refapp-3.x/03-settings/settings.js
@@ -31,7 +31,14 @@ When('the user can change the locale to Spanish', () => {
 
 Then('the text should change into spanish', () => {
     cy.get('button[name="SearchPatientIcon"]').click({force: true});
-    cy.getByPlaceholder('Buscar un paciente');
+    cy.get('input').then(($input) => {
+        if (cy.get($input).invoke('attr', 'placeholder').should('contain', 'Buscar un paciente') === true) {
+            cy.getByPlaceholder('Buscar un paciente');
+        }else{
+            cy.reload();
+            cy.get('button[name="SearchPatientIcon"]').click({force: true});
+            cy.getByPlaceholder('Buscar un paciente');
+    }});
 });
 
 When('the user clicks on the users icon', () => {

--- a/qaframework-bdd-tests/src/test/resources/features/refapp-3.x/03-settings/settings.feature
+++ b/qaframework-bdd-tests/src/test/resources/features/refapp-3.x/03-settings/settings.feature
@@ -15,9 +15,9 @@ Feature: User Settings
   Scenario: The user should be able to change the location
     When the user clicks on the users icon
     Then the current location should be there
-    When the user change the location to "Pharmacy"
+    When the user change the location to "Inpatient Ward"
     Then the user should be on the patient’s chart
-    And the current location should be "Pharmacy"
+    And the current location should be "Inpatient Ward"
 
   @logout
   Scenario: The user should be able to log out and find themselves back on the login


### PR DESCRIPTION
The purpose of this PR is to fix [O3-1057](https://issues.openmrs.org/browse/O3-1057).

Approach
Run 3.x user settings E2E test in a dockerized environment.
Removed location Pharmacy and Replace Inpatient Ward