### PR TITLE
Switch legacy tests to run on qa server on github actions

### DIFF
--- a/qaframework-bdd-tests/src/test/resources/org/openmrs/uitestframework/test-local.properties
+++ b/qaframework-bdd-tests/src/test/resources/org/openmrs/uitestframework/test-local.properties
@@ -1,10 +1,9 @@
-webapp.url=http://localhost:8080/openmrs
+webapp.url=https://qa-refapp.openmrs.org/openmrs
 login.username=admin
 login.password=Admin123
 login.location=Pharmacy
 webdriver=firefox
 login.auto=false
 headless=true
-db.host=openmrs
 webdriver.gecko.driver=firefoxdriver/linux/geckodriver
 includes.csrftoken=true


### PR DESCRIPTION
Selenium Legacy tests fail on the local host hence we can have them run on qa server in github actions.
cc: @sherrif10 