### PR TITLE
Segregate which workflows get run based on which files are touched

### DIFF
--- a/.github/workflows/ocl-subscription-module.yml
+++ b/.github/workflows/ocl-subscription-module.yml
@@ -4,9 +4,14 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/cypress/**/*.*"
+      - "qaframework-bdd-tests/cypress.json"
+      - "qaframework-bdd-tests/package.json"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-clinical-visit.yml
+++ b/.github/workflows/refapp-2x-clinical-visit.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-condition.yml
+++ b/.github/workflows/refapp-2x-condition.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-find-Patient.yml
+++ b/.github/workflows/refapp-2x-find-Patient.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-form.yml
+++ b/.github/workflows/refapp-2x-form.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-inpatient.yml
+++ b/.github/workflows/refapp-2x-inpatient.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-legacy.yml
+++ b/.github/workflows/refapp-2x-legacy.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-login.yml
+++ b/.github/workflows/refapp-2x-login.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-patient-allergies.yml
+++ b/.github/workflows/refapp-2x-patient-allergies.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-patient-demographics.yml
+++ b/.github/workflows/refapp-2x-patient-demographics.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-patient-record.yml
+++ b/.github/workflows/refapp-2x-patient-record.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-patient-visit.yml
+++ b/.github/workflows/refapp-2x-patient-visit.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-person.yml
+++ b/.github/workflows/refapp-2x-person.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-phoneNumberValidation.yml
+++ b/.github/workflows/refapp-2x-phoneNumberValidation.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-provider.yml
+++ b/.github/workflows/refapp-2x-provider.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-registration.yml
+++ b/.github/workflows/refapp-2x-registration.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-report.yml
+++ b/.github/workflows/refapp-2x-report.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-roles-and-privileges.yml
+++ b/.github/workflows/refapp-2x-roles-and-privileges.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-user-account.yml
+++ b/.github/workflows/refapp-2x-user-account.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-visit-type.yml
+++ b/.github/workflows/refapp-2x-visit-type.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-2x-vitals-and-triaging.yml
+++ b/.github/workflows/refapp-2x-vitals-and-triaging.yml
@@ -4,6 +4,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+    paths:
+      - "qaframework-bdd-tests/src/**/*.*"
   repository_dispatch:
     types: [qa]
   workflow_dispatch:

--- a/.github/workflows/refapp-3x-clinical-visit.yml
+++ b/.github/workflows/refapp-3x-clinical-visit.yml
@@ -4,6 +4,10 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths:
+      - "qaframework-bdd-tests/cypress/**/*.*"
+      - "qaframework-bdd-tests/cypress.json"
+      - "qaframework-bdd-tests/package.json"
   repository_dispatch:
     types: [ qa ]
   workflow_dispatch:
@@ -12,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./qaframework-bdd-tests
+        working-directory: qaframework-bdd-tests
     steps:
       - uses: actions/checkout@v2
       - name: Using Node.js

--- a/.github/workflows/refapp-3x-login.yml
+++ b/.github/workflows/refapp-3x-login.yml
@@ -4,6 +4,10 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths:
+      - "qaframework-bdd-tests/cypress/**/*.*"
+      - "qaframework-bdd-tests/cypress.json"
+      - "qaframework-bdd-tests/package.json"
   repository_dispatch:
     types: [ qa ]
   workflow_dispatch:
@@ -12,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./qaframework-bdd-tests
+        working-directory: qaframework-bdd-tests
     steps:
       - uses: actions/checkout@v2
       - name: Using Node.js

--- a/.github/workflows/refapp-3x-patient-registration.yml
+++ b/.github/workflows/refapp-3x-patient-registration.yml
@@ -4,6 +4,10 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths:
+      - "qaframework-bdd-tests/cypress/**/*.*"
+      - "qaframework-bdd-tests/cypress.json"
+      - "qaframework-bdd-tests/package.json"
   repository_dispatch:
     types: [ qa ]
   workflow_dispatch:
@@ -12,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./qaframework-bdd-tests
+        working-directory: qaframework-bdd-tests
     steps:
       - uses: actions/checkout@v2
       - name: Using Node.js

--- a/.github/workflows/refapp-3x-patient-search.yml
+++ b/.github/workflows/refapp-3x-patient-search.yml
@@ -4,6 +4,10 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths:
+      - "qaframework-bdd-tests/cypress/**/*.*"
+      - "qaframework-bdd-tests/cypress.json"
+      - "qaframework-bdd-tests/package.json"
   repository_dispatch:
     types: [ qa ]
   workflow_dispatch:
@@ -12,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./qaframework-bdd-tests
+        working-directory: qaframework-bdd-tests
     steps:
       - uses: actions/checkout@v2
       - name: Using Node.js

--- a/.github/workflows/refapp-3x-settings.yml
+++ b/.github/workflows/refapp-3x-settings.yml
@@ -4,6 +4,10 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths:
+      - "qaframework-bdd-tests/cypress/**/*.*"
+      - "qaframework-bdd-tests/cypress.json"
+      - "qaframework-bdd-tests/package.json"
   repository_dispatch:
     types: [ qa ]
   workflow_dispatch:
@@ -12,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./qaframework-bdd-tests
+        working-directory: qaframework-bdd-tests
     steps:
       - uses: actions/checkout@v2
       - name: Using Node.js

--- a/.github/workflows/refapp-3x-vitals-and-triage.yml
+++ b/.github/workflows/refapp-3x-vitals-and-triage.yml
@@ -4,6 +4,10 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths:
+      - "qaframework-bdd-tests/cypress/**/*.*"
+      - "qaframework-bdd-tests/cypress.json"
+      - "qaframework-bdd-tests/package.json"
   repository_dispatch:
     types: [ qa ]
   workflow_dispatch:
@@ -12,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./qaframework-bdd-tests
+        working-directory: qaframework-bdd-tests
     steps:
       - uses: actions/checkout@v2
       - name: Using Node.js


### PR DESCRIPTION
What this does is determine (for PRs only) which jobs should be run based on which files were touched. I noticed that, e.g., when looking at [this PR](https://github.com/openmrs/openmrs-contrib-qaframework/pull/379) none of the 3.x jobs were being run... never mind the actual job that was supposed to fix. We should actually probably limit this down further for pushes etc. as we can only have 20 jobs run at one time, so, e.g., on push other jobs aren't necessarily being run.

PS This PR itself should have no jobs run since it didn't touch any of the files.