### PR TITLE
Update cypress version and fix failing E2E test.

### DIFF
--- a/qaframework-bdd-tests/package.json
+++ b/qaframework-bdd-tests/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "@testing-library/cypress": "^8.0.0",
     "@types/uuid": "3.4.7",
-    "cypress": "^8.2.0",
+    "cypress": "^9.5.3",
     "cypress-cucumber-preprocessor": "^4.0.1",
     "cypress-file-upload": "^5.0.8"
   },


### PR DESCRIPTION
## Purpose
The purpose of this PR is to update the cypress version and fix failing E2E tests.

## Approach
Update the cypress version.