### PR TITLE
RATEST-327: cypress baseUrl should point to https://dev3.openmrs.org/openmrs/spa

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ MySQL password should be the same for initialSetupTests as openmrs password
     ```
     npm install
     ```
-You don’t need to set up an OpenMRS instance since we use a [cloud instance](https://openmrs-spa.org/openmrs/spa) for the test backend.
+You don’t need to set up an OpenMRS instance since we use a [cloud instance](https://dev3.openmrs.org/openmrs/spa) for the test backend.
 
 ## Running tests`
 

--- a/qaframework-bdd-tests/cypress.json
+++ b/qaframework-bdd-tests/cypress.json
@@ -6,7 +6,7 @@
   ],
   "video": true,
   "defaultCommandTimeout": 120000,
-  "baseUrl": "https://openmrs-spa.org/openmrs/spa",
+  "baseUrl": "https://dev3.openmrs.org/openmrs/spa",
   "env": {
     "API_BASE_URL": "https://openmrs-spa.org/openmrs/ws/rest/v1",
     "ADMIN_USERNAME": "admin2",


### PR DESCRIPTION
Issue link
https://issues.openmrs.org/browse/RATEST-327

Description:
I think its worth for us to change our cloud instance to point to https://dev3.openmrs.org/openmrs/spa since it is were latest changes are deployed 

cc @sherrif10 @kdaud @dkayiwa