### PR TITLE
FM2-460: Create a real integration test for the Patient domain

### DIFF
--- a/qaframework-bdd-tests/cypress.json
+++ b/qaframework-bdd-tests/cypress.json
@@ -6,9 +6,10 @@
   ],
   "video": true,
   "defaultCommandTimeout": 120000,
-  "baseUrl": "https://dev3.openmrs.org/openmrs/spa",
+  "baseUrl": "https://openmrs-spa.org/openmrs/spa",
   "env": {
     "API_BASE_URL": "https://openmrs-spa.org/openmrs/ws/rest/v1",
+    "FHIR_API_BASE_URL": "https://openmrs-spa.org/openmrs/ws/fhir2/R4",
     "ADMIN_USERNAME": "admin2",
     "ADMIN_PASSWORD": "Admin123",
     "ADMIN_UUID": "fbd7a058-88c4-4747-b572-32aaf8ef6ac9",

--- a/qaframework-bdd-tests/cypress/integration/cucumber/step_definitions/fhir/patientDomain.js
+++ b/qaframework-bdd-tests/cypress/integration/cucumber/step_definitions/fhir/patientDomain.js
@@ -1,0 +1,34 @@
+import {Given, Then, And, When} from 'cypress-cucumber-preprocessor/steps';
+
+const FHIR_API_BASE_URL = Cypress.env('FHIR_API_BASE_URL');
+
+Given('the user login to the Registration Desk', () => {    
+  cy.login();
+  cy.visit('home');
+});
+
+When('GET - single patient domain by {string}', uuid => {
+  const patientUrl = FHIR_API_BASE_URL + '/Patient/' + uuid;
+  cy.request({
+    method: 'GET',
+    url: patientUrl,
+    headers: {
+      'Content-Type': 'application/json'  
+    },
+    failOnStatusCode:false
+  }).as('patient');
+});
+
+Then('verify response status code is {int}', code => {
+  cy.get('@patient').then(patient => {
+    expect(patient.status).to.eq(code);
+  });
+});
+
+And('patient has {string} and {string}', (identifier, name)  => {
+  cy.get('@patient').then(patient => {
+    assert.isObject(patient.body, 'Patient Response is an Object');
+    assert.equal(patient.body.identifier[0].id, identifier);
+    assert.equal(patient.body.name[0].id, name);
+  });
+});

--- a/qaframework-bdd-tests/cypress/support/commands.js
+++ b/qaframework-bdd-tests/cypress/support/commands.js
@@ -44,7 +44,10 @@ Cypress.Commands.add('login', () => {
     cy.request({
         method: 'POST',
         url: `${API_BASE_URL}/session`,
-        body: {sessionLocation: DEFAULT_LOCATION_UUID},
+        body: {
+          sessionLocation: DEFAULT_LOCATION_UUID, 
+          locale: "en_GB",
+        },
         headers: {
             'Content-Type': 'application/json',
             Authorization: `Basic ${TOKEN}`,

--- a/qaframework-bdd-tests/package.json
+++ b/qaframework-bdd-tests/package.json
@@ -45,7 +45,8 @@
     "refapp3Settings": "cypress run --spec src/test/resources/features/refapp-3.x/03-settings/settings.feature",
     "refapp3ClinicalVisit": "cypress run --spec src/test/resources/features/refapp-3.x/04-clinical-visit/clinical-visit.feature",
     "refapp3VitalsAndTriage": "cypress run --spec src/test/resources/features/refapp-3.x/05-vitals-and-triage/vitals-and-triage.feature",
-    "refappOclSubscriptionModule": "cypress run --spec src/test/resources/features/ocl/ocl-subscription-module.feature"
+    "refappOclSubscriptionModule": "cypress run --spec src/test/resources/features/ocl/ocl-subscription-module.feature",
+    "fhirPatientDomain": "cypress run --spec src/test/resources/features/fhir/patientDomain.feature"
   },
   "devDependencies": {
     "@testing-library/cypress": "^8.0.0",

--- a/qaframework-bdd-tests/src/test/resources/features/fhir/patientDomain.feature
+++ b/qaframework-bdd-tests/src/test/resources/features/fhir/patientDomain.feature
@@ -1,0 +1,13 @@
+Feature: Patient Domain
+
+  Background:
+    Given the user login to the Registration Desk
+
+  Scenario Outline: Test FHIR Patient Domain
+    When GET - single patient domain by "<uuid>"
+    Then verify response status code is <code> 
+    And patient has "<identifier>" and "<name>"
+
+    Examples:
+    | uuid                                  | code | identifier                           | name                                 |
+    | 6007b8d8-b00a-4d68-8408-d9e9c303f305  | 200  | e8f561b4-d6af-4ef7-9fa8-f45c6fba4c80 | 4fc37731-4363-482c-aa02-e29c7e3e73d9 |


### PR DESCRIPTION
## Issue link
https://issues.openmrs.org/browse/FM2-460

For the start, i have first automated only the GET on `Patient/<uuid>`.  
I have created these automations here rather than in https://github.com/openmrs/openmrs-module-fhir2 because i thought it would be easier to track information.

<img width="1230" alt="Screenshot 2022-05-10 at 10 26 53" src="https://user-images.githubusercontent.com/58003327/167583445-a8c46211-8b50-4456-8a21-a69923620da1.png">

cc @ibacher @dkayiwa @kdaud @sherrif10 