### PR TITLE
Resolve All firefox failures

### DIFF
--- a/qaframework-bdd-tests/src/main/java/org/openmrs/contrib/qaframework/page/VisitNotePage.java
+++ b/qaframework-bdd-tests/src/main/java/org/openmrs/contrib/qaframework/page/VisitNotePage.java
@@ -20,7 +20,7 @@ public class VisitNotePage extends Page {
 	private static final By CODE = By.className("code");
 	private static final By UI_ID_1 = By.id("ui-id-1");
 	private static final By UI_MENU_ITEM = By.className("ui-menu-item");
-	private static final By PRIMARY_DIAGNOSIS_ELEMENT = By.cssSelector(".diagnosis.primary .matched-name");
+	private static final By PRIMARY_DIAGNOSIS_ELEMENT = By.xpath("//ul[1]/li/span/div/strong");
 	private static final By SECONDARY_DIAGNOSIS_ELEMENT = By.xpath("//ul[2]/li/span/div/strong");
 	private static final By SAVE_VISIT_NOTE = By.cssSelector(".submitButton.confirm");
 	private static final By NOTE = By.id("w10");

--- a/qaframework-bdd-tests/src/main/java/org/openmrs/contrib/qaframework/page/VisitNotePage.java
+++ b/qaframework-bdd-tests/src/main/java/org/openmrs/contrib/qaframework/page/VisitNotePage.java
@@ -20,7 +20,7 @@ public class VisitNotePage extends Page {
 	private static final By CODE = By.className("code");
 	private static final By UI_ID_1 = By.id("ui-id-1");
 	private static final By UI_MENU_ITEM = By.className("ui-menu-item");
-	private static final By PRIMARY_DIAGNOSIS_ELEMENT = By.xpath("//ul[1]/li/span/div/strong");
+	private static final By PRIMARY_DIAGNOSIS_ELEMENT = By.cssSelector(".diagnosis.primary .matched-name");
 	private static final By SECONDARY_DIAGNOSIS_ELEMENT = By.xpath("//ul[2]/li/span/div/strong");
 	private static final By SAVE_VISIT_NOTE = By.cssSelector(".submitButton.confirm");
 	private static final By NOTE = By.id("w10");

--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/VisitNoteSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/VisitNoteSteps.java
@@ -29,9 +29,9 @@ public class VisitNoteSteps extends Steps {
 
     private static final String DIAGNOSIS_PRIMARY = "Cancer";
     private static final String DIAGNOSIS_SECONDARY = "Malaria";
-    private static final String DIAGNOSIS_SECONDARY_UPDATED = "Pneumonia";
     private ActiveVisitsPage activeVisitsPage;
     private VisitNotePage visitNotePage;
+    private static final String DIAGNOSIS_SECONDARY_UPDATED = "Pneumonia";
     private TestData.PatientInfo testPatient;
 
     @Before(RunTest.HOOK.SELENIUM_VISIT_NOTE)
@@ -119,7 +119,7 @@ public class VisitNoteSteps extends Steps {
 
     @Then("the system saves the diagnosis into the visit note table")
     public void systemAddsDiagnosis() {
-        assertEquals("Pneumonia", visitNotePage.primaryDiagnosis());
+        assertEquals(DIAGNOSIS_SECONDARY_UPDATED, visitNotePage.primaryDiagnosis());
         assertEquals("Bleeding", visitNotePage.secondaryDiagnosis());
     }
 

--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/VisitNoteSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/VisitNoteSteps.java
@@ -9,9 +9,9 @@
  */
 package org.openmrs.contrib.qaframework.automation;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
 
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
@@ -29,9 +29,9 @@ public class VisitNoteSteps extends Steps {
 
     private static final String DIAGNOSIS_PRIMARY = "Cancer";
     private static final String DIAGNOSIS_SECONDARY = "Malaria";
+    private static final String DIAGNOSIS_SECONDARY_UPDATED = "Pneumonia";
     private ActiveVisitsPage activeVisitsPage;
     private VisitNotePage visitNotePage;
-    private static final String DIAGNOSIS_SECONDARY_UPDATED = "Pneumonia";
     private TestData.PatientInfo testPatient;
 
     @Before(RunTest.HOOK.SELENIUM_VISIT_NOTE)
@@ -131,7 +131,8 @@ public class VisitNoteSteps extends Steps {
     }
 
     @Then("the system deletes the visit note")
-    public void systemdeletesVisitNotePage() {
+    public void systemDeletesVisitNotePage() {
         assertTrue(textExists("deleted"));
     }
+    
 }

--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/VitalsAndTriagingSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/VitalsAndTriagingSteps.java
@@ -173,6 +173,5 @@ public class VitalsAndTriagingSteps extends Steps {
 	@And("a user clicks on the save changes button")
 	public void saveUpdatedVitals() {
 		editVitalsPage.saveChanges();
-		editVitalsPage.waitForPage();
 	}
 }


### PR DESCRIPTION
These changes are catering for the following resolutions

1. Resolve visibility exceptions in visitNote according to this https://github.com/openmrs/openmrs-contrib-qaframework/runs/7000791006?check_suite_focus=true.
2. Use javascript executor instead of clickable to enable browser find a desired element to click on.

cc @kdaud