### PR TITLE
Added chrome options to fix DevToolsActivePort failures on ci

### DIFF
--- a/qaframework-bdd-tests/src/main/java/org/openmrs/contrib/qaframework/helper/TestBase.java
+++ b/qaframework-bdd-tests/src/main/java/org/openmrs/contrib/qaframework/helper/TestBase.java
@@ -211,6 +211,8 @@ public class TestBase {
 		FirefoxOptions firefoxOptions = new FirefoxOptions();
 		if ("true".equals(TestProperties.instance().getHeadless())) {
 			firefoxOptions.addArguments("--headless");
+			firefoxOptions.addArguments("--no-sandbox");
+			firefoxOptions.addArguments("--disable-dev-shm-usage");
 		}
 		driver = new FirefoxDriver(firefoxOptions);
 		return driver;

--- a/qaframework-bdd-tests/src/main/java/org/openmrs/contrib/qaframework/helper/TestBase.java
+++ b/qaframework-bdd-tests/src/main/java/org/openmrs/contrib/qaframework/helper/TestBase.java
@@ -275,6 +275,8 @@ public class TestBase {
 		ChromeOptions chromeOptions = new ChromeOptions();
 		if ("true".equals(TestProperties.instance().getHeadless())) {
 			chromeOptions.addArguments("--headless");
+			chromeOptions.addArguments("--no-sandbox");
+			chromeOptions.addArguments("--disable-dev-shm-usage");
 		}
 		driver = new ChromeDriver(chromeOptions);
 		return driver;


### PR DESCRIPTION
Basing on the continuing ci failures after a number of rebuilds as [reflected here](https://ci.openmrs.org/download/CONTRIB-QA-FRAMEWORK/build_logs/CONTRIB-QA-FRAMEWORK-1654.log). i believe this solution might resolve ci failures by adding an argument to the chromeOptions starting  chrome webdriver.
cc @dkayiwa @ibacher  @kdaud 