### PR TITLE
RATEST-341: Fix the base url of cypress tests

### DIFF
--- a/qaframework-bdd-tests/cypress.json
+++ b/qaframework-bdd-tests/cypress.json
@@ -6,9 +6,9 @@
   ],
   "video": true,
   "defaultCommandTimeout": 20000,
-  "baseUrl": "http://localhost/openmrs/spa",
+  "baseUrl": "http://localhost:8080/openmrs",
   "env": {
-    "API_BASE_URL": "http://localhost/openmrs/ws/rest/v1",
+    "API_BASE_URL": "http://localhost:8080/openmrs/ws/rest/v1",
     "ADMIN_USERNAME": "admin",
     "ADMIN_PASSWORD": "Admin123",
     "ADMIN_UUID": "82f18b44-6814-11e8-923f-e9a88dcb533f",


### PR DESCRIPTION
## Summary
2.x OCL Subscription Module tests were failing due to an incorrect baseURL.
Updated the baseURL with the correct url.

## Screenshots

**Tested with GitHub actions:**
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/27498587/218497144-8284b7a6-4d6c-4bbf-b98e-793787a1ff11.png">

## Related Issue
https://issues.openmrs.org/projects/RATEST/issues/RATEST-341
