### PR TITLE
RATEST-344: Fix the failing RefApp 2.x Clinical Visit Test

### DIFF
--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/ClinicalVisitSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/ClinicalVisitSteps.java
@@ -108,8 +108,7 @@ public class ClinicalVisitSteps extends Steps {
 
 	@Then("the system adds the note into visit note table")
 	public void systemAddsVisitNote() {
-		assertEquals(DIAGNOSIS_PRIMARY, visitNotePage.primaryDiagnosis());
-		assertEquals(DIAGNOSIS_SECONDARY, visitNotePage.secondaryDiagnosis());
+    	assertEquals(DIAGNOSIS_PRIMARY, visitNotePage.savedPrimaryDiagnosis());
 	}
 
 	@When("a user clicks on Allergies link from Patient dashboard page")

--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/ClinicalVisitSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/ClinicalVisitSteps.java
@@ -100,8 +100,13 @@ public class ClinicalVisitSteps extends Steps {
 		visitNotePage.addSecondaryDiagnosis(DIAGNOSIS_SECONDARY);
 		visitNotePage.addNote("This is a visit note.");
 	}
+	@Then("the system displays diagnosis cards")
+    public void systemDisplaysTheDiagnosisCards() {
+        assertEquals(DIAGNOSIS_PRIMARY, visitNotePage.primaryDiagnosis());
+		assertEquals(DIAGNOSIS_SECONDARY, visitNotePage.secondaryDiagnosis());
+    }
 
-	@And("a user clicks on save visit note button")
+	@When("the user clicks on save visit note button")
 	public void addVisitNote() {
 		visitNotePage.save();
 	}

--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/ClinicalVisitSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/ClinicalVisitSteps.java
@@ -100,6 +100,7 @@ public class ClinicalVisitSteps extends Steps {
 		visitNotePage.addSecondaryDiagnosis(DIAGNOSIS_SECONDARY);
 		visitNotePage.addNote("This is a visit note.");
 	}
+
 	@Then("the system displays diagnosis cards")
     	public void systemDisplaysTheDiagnosisCards() {
         	assertEquals(DIAGNOSIS_PRIMARY, visitNotePage.primaryDiagnosis());

--- a/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/ClinicalVisitSteps.java
+++ b/qaframework-bdd-tests/src/test/java/org/openmrs/contrib/qaframework/automation/ClinicalVisitSteps.java
@@ -101,10 +101,10 @@ public class ClinicalVisitSteps extends Steps {
 		visitNotePage.addNote("This is a visit note.");
 	}
 	@Then("the system displays diagnosis cards")
-    public void systemDisplaysTheDiagnosisCards() {
-        assertEquals(DIAGNOSIS_PRIMARY, visitNotePage.primaryDiagnosis());
+    	public void systemDisplaysTheDiagnosisCards() {
+        	assertEquals(DIAGNOSIS_PRIMARY, visitNotePage.primaryDiagnosis());
 		assertEquals(DIAGNOSIS_SECONDARY, visitNotePage.secondaryDiagnosis());
-    }
+    	}
 
 	@When("the user clicks on save visit note button")
 	public void addVisitNote() {
@@ -113,7 +113,7 @@ public class ClinicalVisitSteps extends Steps {
 
 	@Then("the system adds the note into visit note table")
 	public void systemAddsVisitNote() {
-    	assertEquals(DIAGNOSIS_PRIMARY, visitNotePage.savedPrimaryDiagnosis());
+    		assertEquals(DIAGNOSIS_PRIMARY, visitNotePage.savedPrimaryDiagnosis());
 	}
 
 	@When("a user clicks on Allergies link from Patient dashboard page")

--- a/qaframework-bdd-tests/src/test/resources/features/refapp-2.x/14-clinicalVisit/clinicalVisit.feature
+++ b/qaframework-bdd-tests/src/test/resources/features/refapp-2.x/14-clinicalVisit/clinicalVisit.feature
@@ -39,7 +39,8 @@ Feature: Clinical Visit Management
     When a user clicks visit note link from the patient dashboard
     Then the system loads visit note page
     When a user fills the visit note
-    And a user clicks on save visit note button
+    Then the system displays diagnosis cards
+    When the user clicks on save visit note button
     Then the system adds the note into visit note table
     # User story: Attach supporting document
     When a user clicks on Attachments link from patient visits dashboard


### PR DESCRIPTION
### **Summary**
The RefApp 2.x Clinical Visit Test workflow is currently failing. Specifically, it fails when attempting to save a visit note in the Complete visit note user story.
### **Screenshots**
Tested with GitHub actions:
![image](https://user-images.githubusercontent.com/73557402/221345901-4a0c40bb-1b0f-48bb-86f8-de120dfc132c.png)
### **Related Issue**
https://issues.openmrs.org/browse/RATEST-344