### PR TITLE
RATEST-347: Allow remote connections to Chrome from any origin

### DIFF
--- a/qaframework-bdd-tests/src/main/java/org/openmrs/contrib/qaframework/helper/TestBase.java
+++ b/qaframework-bdd-tests/src/main/java/org/openmrs/contrib/qaframework/helper/TestBase.java
@@ -267,6 +267,7 @@ public class TestBase {
 		System.setProperty(ChromeDriverService.CHROME_DRIVER_LOG_PROPERTY,
 				chromedriverFilesDir + "/chromedriver-" + getClass().getSimpleName() + ".log");
 		ChromeOptions chromeOptions = new ChromeOptions();
+		chromeOptions.addArguments("--remote-allow-origins=*");
 		if ("true".equals(TestProperties.instance().getHeadless())) {
 			chromeOptions.addArguments("--headless");
 			chromeOptions.addArguments("--no-sandbox");


### PR DESCRIPTION

## Summary

For some OS.... While Running e2e tests ..this is thrown https://pastebin.com/L8QbmwB6 


## Worked On Issue

👓  https://issues.openmrs.org/browse/RATEST-347 

cc @sherrif10 @jayasanka-sack @Piumal1999 @kdaud 