### PR TITLE
O3-2123: Remove the bamboo build status icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@ ___
 ## Platform (core)
 
 [TRUNK](https://ci.openmrs.org/browse/TRUNK-MASTER) | [REST API](https://ci.openmrs.org/browse/RESTWS-RESTWS) | [FHIR API](https://ci.openmrs.org/browse/FHIR-FM2) | [SONAQUBE DASHBOARD](https://sonar.openmrs.org/dashboard?id=org.openmrs%3Aopenmrs)
------------- | ------------- | ------------- | -------------
-![Build Status](https://ci.openmrs.org/plugins/servlet/wittified/build-status/TRUNK-MASTER) | ![Build Status](https://ci.openmrs.org/plugins/servlet/wittified/build-status/RESTWS-RESTWS) | ![Build Status](https://ci.openmrs.org/plugins/servlet/wittified/build-status/FHIR-FM2) | ![Build Status](https://ci.openmrs.org/plugins/servlet/wittified/build-status/SON-OPENMRSCOREMASTER)
 
 
 Install & Upgrade Tests |
@@ -19,7 +17,6 @@ Install & Upgrade Tests |
 
 2.x RefApp Workflow Tests |
 ------------- |
-[All Chrome Tests](https://ci.openmrs.org/browse/CONTRIB-QA) ![Build Status](https://ci.openmrs.org/plugins/servlet/wittified/build-status/CONTRIB-QA)
 [![All Firefox Tests](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/qa.yml/badge.svg?branch=master)](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/qa.yml)
 [![RefApp 2.x Clinical Visit](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-2x-clinical-visit.yml/badge.svg)](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-2x-clinical-visit.yml)
 [![RefApp 2.x Patient Condition](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-2x-condition.yml/badge.svg)](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-2x-condition.yml)
@@ -51,9 +48,9 @@ Install & Upgrade Tests |
 
 2.x RefApp Feature-Specific Tests* |
 ------------- |
-[Legacy Selenium Chrome](https://ci.openmrs.org/browse/REFAPP-UI) ![Build Status](https://ci.openmrs.org/plugins/servlet/wittified/build-status/REFAPP-UI)
+[Legacy Selenium Chrome](https://ci.openmrs.org/browse/REFAPP-UI) 
 [![Legacy Selenium Firefox](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-2x-legacy.yml/badge.svg)](https://github.com/openmrs/openmrs-contrib-qaframework/actions/workflows/refapp-2x-legacy.yml)
-[Legacy UI](https://ci.openmrs.org/browse/LU-LU) ![Build Status](https://ci.openmrs.org/plugins/servlet/wittified/build-status/LU-LU) 
+[Legacy UI](https://ci.openmrs.org/browse/LU-LU)
 ###### * Detailed list of Legacy Selenium Tests [here](https://github.com/openmrs/openmrs-contrib-qaframework/tree/master/qaframework-legacy-tests/src/test/java/org/openmrs/contrib/qaframework/legacy).
 
 ___

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ___
 ## Platform (core)
 
 [TRUNK](https://ci.openmrs.org/browse/TRUNK-MASTER) | [REST API](https://ci.openmrs.org/browse/RESTWS-RESTWS) | [FHIR API](https://ci.openmrs.org/browse/FHIR-FM2) | [SONAQUBE DASHBOARD](https://sonar.openmrs.org/dashboard?id=org.openmrs%3Aopenmrs)
-
+------------ | ------------- | ------------- | -------------
 
 Install & Upgrade Tests |
 ------------- |


### PR DESCRIPTION

## Summary
- Removed bamboo icon status badges

## Related Issue
🙄  https://issues.openmrs.org/browse/O3-2123

## Screenshots
![Screenshot from 2023-05-18 17-38-52](https://github.com/openmrs/openmrs-contrib-qaframework/assets/86114366/844e395e-dce5-4c6f-b193-eb3d09d0f881)
