### PR TITLE
RATEST-352: Bump node version to 16.20.0

### DIFF
--- a/qaframework-bdd-tests/pom.xml
+++ b/qaframework-bdd-tests/pom.xml
@@ -84,7 +84,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <nodeVersion>v15.8.0</nodeVersion>
+                            <nodeVersion>v16.20.0</nodeVersion>
                             <installDirectory>./</installDirectory>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] I have tested the changes locally and verified that they work as intended.
- [x] I have added comments to my code where necessary to help others understand my changes.
- [x] I have read and agree to the Contributing Guidelines of this project.


## Summary

The tests were failing due a mismatch in the node version. We had configured it to run the workflows with node 16 while the version we install through pom.xml was node 15. So the pom.xml was updated to use node 16.

<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

https://issues.openmrs.org/projects/RATEST/issues/RATEST-352
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->