### PR TITLE
Add a cron job to run 2.x e2e tests every  Monday, Wednesday & Friday

### DIFF
--- a/.github/workflows/platform-install-advanced.yml
+++ b/.github/workflows/platform-install-advanced.yml
@@ -1,5 +1,7 @@
 name: Platform Advanced Installation
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   repository_dispatch:

--- a/.github/workflows/platform-install-postgres.yml
+++ b/.github/workflows/platform-install-postgres.yml
@@ -1,5 +1,7 @@
 name: Platform Postgres Installation
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   repository_dispatch:

--- a/.github/workflows/platform-install-simple.yml
+++ b/.github/workflows/platform-install-simple.yml
@@ -1,5 +1,7 @@
 name: Platform Simple Installation
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   workflow_dispatch:
   push:
     branches: [master]

--- a/.github/workflows/platform-install-testing.yml
+++ b/.github/workflows/platform-install-testing.yml
@@ -1,5 +1,7 @@
 name: Platform Testing Installation
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   repository_dispatch:

--- a/.github/workflows/platform-upgrade.yml
+++ b/.github/workflows/platform-upgrade.yml
@@ -1,5 +1,7 @@
 name: Platform Upgrade
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   workflow_dispatch:
   push:
     branches: [master]

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,5 +1,7 @@
 name: All Browser Tests
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-appointment.yml
+++ b/.github/workflows/refapp-2x-appointment.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Appointment
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-clinical-visit.yml
+++ b/.github/workflows/refapp-2x-clinical-visit.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Clinical Visit
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-condition.yml
+++ b/.github/workflows/refapp-2x-condition.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Patient Condition
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-find-Patient.yml
+++ b/.github/workflows/refapp-2x-find-Patient.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Find Patient
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-form.yml
+++ b/.github/workflows/refapp-2x-form.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Form
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-inpatient.yml
+++ b/.github/workflows/refapp-2x-inpatient.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Inpatient
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-legacy.yml
+++ b/.github/workflows/refapp-2x-legacy.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Legacy Selenium Tests
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-location-management.yml
+++ b/.github/workflows/refapp-2x-location-management.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Location Management
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-login.yml
+++ b/.github/workflows/refapp-2x-login.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Login
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-module.yml
+++ b/.github/workflows/refapp-2x-module.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Module
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-open-concept-lab.yml
+++ b/.github/workflows/refapp-2x-open-concept-lab.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Open Concept Lab
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-patient-allergies.yml
+++ b/.github/workflows/refapp-2x-patient-allergies.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Patient Allergies
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-patient-demographics.yml
+++ b/.github/workflows/refapp-2x-patient-demographics.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Patient Demographics
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-patient-encounter.yml
+++ b/.github/workflows/refapp-2x-patient-encounter.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Patient Encounter
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-patient-record.yml
+++ b/.github/workflows/refapp-2x-patient-record.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Patient Record
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-patient-visit.yml
+++ b/.github/workflows/refapp-2x-patient-visit.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Patient Visit
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-person.yml
+++ b/.github/workflows/refapp-2x-person.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Person
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-phoneNumberValidation.yml
+++ b/.github/workflows/refapp-2x-phoneNumberValidation.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Phone Number validation
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-provider.yml
+++ b/.github/workflows/refapp-2x-provider.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Provider
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-registration.yml
+++ b/.github/workflows/refapp-2x-registration.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Patient Registration
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-report.yml
+++ b/.github/workflows/refapp-2x-report.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Reports
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-roles-and-privileges.yml
+++ b/.github/workflows/refapp-2x-roles-and-privileges.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Roles And Privileges
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-service.yml
+++ b/.github/workflows/refapp-2x-service.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Service
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-user-account.yml
+++ b/.github/workflows/refapp-2x-user-account.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x User Account
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-user.yml
+++ b/.github/workflows/refapp-2x-user.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Add User & Roles
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-visit-note.yml
+++ b/.github/workflows/refapp-2x-visit-note.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Visit Note
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-visit-type.yml
+++ b/.github/workflows/refapp-2x-visit-type.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Visit Type
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:

--- a/.github/workflows/refapp-2x-vitals-and-triaging.yml
+++ b/.github/workflows/refapp-2x-vitals-and-triaging.yml
@@ -1,5 +1,7 @@
 name: RefApp 2.x Vitals And Triaging
 on:
+  schedule:
+    - cron: '0 0 * * 1,3,5'
   push:
     branches: [master]
   pull_request:


### PR DESCRIPTION
This PR is bringing in a change within the workflow to ensure 2.x e2e tests run three times a week ie every Monday, Wednesday and Friday. The current set up only triggers the tests to run on a push and if there isn't any commit done on master for a while the tests won't run.  