### PR TITLE
Bump GitHub Actions to v4

### DIFF
--- a/.github/workflows/platform-install-advanced.yml
+++ b/.github/workflows/platform-install-advanced.yml
@@ -18,11 +18,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout openmrs-core
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: openmrs/openmrs-core
       - name: build platform
@@ -30,7 +31,7 @@ jobs:
           mvn clean install -DskipTests=true
           cp webapp/target/openmrs.war ../
       - name: Checkout qaframework
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: ${{github.repository}}
       - name: run db and web containers

--- a/.github/workflows/platform-install-postgres.yml
+++ b/.github/workflows/platform-install-postgres.yml
@@ -18,11 +18,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout openmrs-core
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: openmrs/openmrs-core
       - name: build platform

--- a/.github/workflows/platform-install-simple.yml
+++ b/.github/workflows/platform-install-simple.yml
@@ -18,11 +18,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout openmrs-core
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: openmrs/openmrs-core
       - name: build platform
@@ -31,7 +32,7 @@ jobs:
           mvn clean install -DskipTests=true
           cp webapp/target/openmrs.war ../
       - name: Checkout qaframework
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: ${{github.repository}}
       - name: run db and web containers

--- a/.github/workflows/platform-install-testing.yml
+++ b/.github/workflows/platform-install-testing.yml
@@ -18,11 +18,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout openmrs-core
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: openmrs/openmrs-core
       - name: build platform
@@ -30,7 +31,7 @@ jobs:
           mvn clean install -DskipTests=true
           cp webapp/target/openmrs.war ../
       - name: Checkout qaframework
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: ${{github.repository}}
       - name: run db and web containers

--- a/.github/workflows/platform-upgrade.yml
+++ b/.github/workflows/platform-upgrade.yml
@@ -18,11 +18,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout openmrs-core
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: openmrs/openmrs-core
       - name: build platform
@@ -31,7 +32,7 @@ jobs:
           mvn clean install -DskipTests=true
           cp webapp/target/openmrs.war ../
       - name: Checkout qaframework
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
         with:
           repository: ${{github.repository}}
       - name: run db and web containers

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run db and web containers
         run: |
           docker-compose -f docker/docker-compose-refqa.yml up -d

--- a/.github/workflows/refapp-2x-appointment.yml
+++ b/.github/workflows/refapp-2x-appointment.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-clinical-visit.yml
+++ b/.github/workflows/refapp-2x-clinical-visit.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run db and web containers
         run: |
           docker-compose -f docker/docker-compose-refqa.yml up -d

--- a/.github/workflows/refapp-2x-condition.yml
+++ b/.github/workflows/refapp-2x-condition.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-find-Patient.yml
+++ b/.github/workflows/refapp-2x-find-Patient.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-form.yml
+++ b/.github/workflows/refapp-2x-form.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-inpatient.yml
+++ b/.github/workflows/refapp-2x-inpatient.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-legacy.yml
+++ b/.github/workflows/refapp-2x-legacy.yml
@@ -25,11 +25,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-location-management.yml
+++ b/.github/workflows/refapp-2x-location-management.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-login.yml
+++ b/.github/workflows/refapp-2x-login.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-module.yml
+++ b/.github/workflows/refapp-2x-module.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-open-concept-lab.yml
+++ b/.github/workflows/refapp-2x-open-concept-lab.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-patient-allergies.yml
+++ b/.github/workflows/refapp-2x-patient-allergies.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-patient-demographics.yml
+++ b/.github/workflows/refapp-2x-patient-demographics.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-patient-encounter.yml
+++ b/.github/workflows/refapp-2x-patient-encounter.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-patient-record.yml
+++ b/.github/workflows/refapp-2x-patient-record.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-patient-visit.yml
+++ b/.github/workflows/refapp-2x-patient-visit.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-person.yml
+++ b/.github/workflows/refapp-2x-person.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-phoneNumberValidation.yml
+++ b/.github/workflows/refapp-2x-phoneNumberValidation.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{github.repository}}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-provider.yml
+++ b/.github/workflows/refapp-2x-provider.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-registration.yml
+++ b/.github/workflows/refapp-2x-registration.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-report.yml
+++ b/.github/workflows/refapp-2x-report.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-roles-and-privileges.yml
+++ b/.github/workflows/refapp-2x-roles-and-privileges.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-service.yml
+++ b/.github/workflows/refapp-2x-service.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-user-account.yml
+++ b/.github/workflows/refapp-2x-user-account.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-user.yml
+++ b/.github/workflows/refapp-2x-user.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-visit-note.yml
+++ b/.github/workflows/refapp-2x-visit-note.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-visit-type.yml
+++ b/.github/workflows/refapp-2x-visit-type.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers

--- a/.github/workflows/refapp-2x-vitals-and-triaging.yml
+++ b/.github/workflows/refapp-2x-vitals-and-triaging.yml
@@ -28,11 +28,12 @@ jobs:
           HUB_PORT: 4444
     steps:
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
-          java-version: 1.8
+          distribution: 'temurin'
+          java-version: '8'
       - name: Checkout qaframework
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
       - name: Run db and web containers


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [ ] I have tested the changes locally and verified that they work as intended.
- [ ] I have added comments to my code where necessary to help others understand my changes.
- [ ] I have read and agree to the Contributing Guidelines of this project.


## Summary
Background: Currently, GitHub Actions is using node 16 and this version reached it's [end of life](https://github.com/nodejs/Release/#end-of-life-releases) on 2023-09-11 as a result we get these warnings...
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20` 
The way forward is to upgrade GitHub Actions to use v4 which defaults to Node.js 20
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

**Before upgrade**

![BeforeUpgrade](https://github.com/openmrs/openmrs-contrib-qaframework/assets/38831673/378b7246-a89e-4b6b-83e3-ca4e90f09a5b)


**After upgrade**

![AfterUpgrade](https://github.com/openmrs/openmrs-contrib-qaframework/assets/38831673/0deb98cc-da34-483a-bce5-a489395ba9dd)




## Related Issue

*None.*
<!--
Required if applicable.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->